### PR TITLE
Rr dev (Trainer Module)

### DIFF
--- a/archs/TCN.py
+++ b/archs/TCN.py
@@ -60,7 +60,7 @@ If task_name = 'forecast' (WIP)
 
 
 """
-import torch
+
 import torch.nn as nn
 import numpy as np
 from torch.nn.utils import weight_norm
@@ -254,7 +254,6 @@ class FinalBlock(nn.Module):
         if self.output_activation:
             out = self.act(out)
         out = out.reshape(out.shape[0], self.desired_out_t, self.desired_out_c)
-            
         return out
 
     def forward(self, x):

--- a/data/regression_dataset.py
+++ b/data/regression_dataset.py
@@ -25,7 +25,6 @@ each value is cast as a Tensor with float type, and the unique sample index is a
 """
 
 # external imports
-import torch
 from torch.utils.data import Dataset, DataLoader
 from torch import is_tensor, from_numpy
 
@@ -70,5 +69,4 @@ class CustomRegressionDataset(Dataset):
         sample = {'x': from_numpy(input_x).float(),
                   'y': from_numpy(output_y).float(),
                   's_id': idx}
-        
         return sample

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -99,10 +99,6 @@ class PLModel(pl.LightningModule):
             elif isinstance(self.loss, str): # only a metric (string) is given, no kwargs
                 loss = self.__get_loss_function(self.loss)(y_pred, y)
                 metrics['train_loss'] = loss
-                
-        if torch.isnan(loss):
-            print("Loss Error: Loss NaN!")
-            exit(101)
         
         if self.performance_metrics:
             if isinstance(self.performance_metrics, dict):


### PR DESCRIPTION
# Trainer module
File: ./trainer/trainer.py

- Allows a user to train a Pytorch model using Knowit's Data Module.
- **KITrainer** A wrapper class that handles the user's training and testing parameters. User can either train a model from scratch or initialize a trained model from checkpoint.
- KITrainer assigns the correct parameters to Pytorch Lightnings Trainer.
- **Training metrics** are displayed in the progress bar during training. Metrics are also logged to the user's output folder (specified in the Env Module) as csv files under the "lightning_logs" subfolder.
- Currently, **metrics and functions** are called from the following libs: train/val/test loss is called from torch.nn.functional, performance metrics are called from torchmetrics.functional.
- It is important to note that the above libs are the functional forms (not their Modular counterparts).
- **Checkpoints** are saved in the user's output folder under the "checkpoints" subfolder. Files are named after the date and time that the run took place.

Todo: Clean up code and add docstrings.

File ./trainer/trainer_examples.py

- Provides an example scratchpad of how to use KITrainer.
- User needs to specify a handful of key parameters of type str, int, float.
- Some parameters may have additional information (optional or compulsory kwargs). If needed, the user passes these parameters to KITrainer as a dictionary: the key is either a str or bool and the value is another dictionary containing values given as str/int/float. 
- To call the correct loss function or performance metric, the user needs to view the documentation as specified above.
- Once KITrainer is initialized with the user's parameters, the user can train the model by calling the ".fit_model()" method on the trainer object. Both the training and validation data is provided as Pytorch dataloaders (from Knowit's Data Module).
- Alternatively, if the user has a pretrained set of models, the user can initialize the model from a checkpoint file (this includes the model's trained weights and hyperparameters).
- To test the model on a eval/test set, the user calls the ".test_model()" method on the trainer object. The test data is a Pytorch dataloader.

Todo: Clean up code and write clear user instructions. Add author name at the beginning.

# Env Module
File: ./env/env_user.py

- Added a line to create a "checkpoints" subdirectory in the user's project folder.
