### PR TITLE
Explosing gradients and weight norm

### DIFF
--- a/archs/CNN.py
+++ b/archs/CNN.py
@@ -180,19 +180,11 @@ class FinalBlock(nn.Module):
 
         if task == 'classification':
             self.trans = nn.Linear(self.expected_in_t * self.expected_in_c, self.desired_out_c, bias=False)
-            self.init_mod(self.trans)
+            init_mod(self.trans)
         elif task == 'regression':
             self.trans = nn.Linear(self.expected_in_t * self.expected_in_c,
                                    self.desired_out_c * self.desired_out_t, bias=False)
-            self.init_mod(self.trans)
-
-    @staticmethod
-    def init_mod(mod):
-        for name, parameters in mod.named_parameters():
-            if 'weight' in name:
-                nn.init.normal_(parameters)
-            elif 'bias' in name:
-                nn.init.zeros_(parameters)
+            init_mod(self.trans)
 
     def classify(self, x):
         x = x.reshape(x.shape[0], self.expected_in_t * self.expected_in_c)
@@ -246,23 +238,15 @@ class ConvBlock(nn.Module):
                                        getattr(nn, activations)(),
                                        nn.Dropout(p=dropout))
 
-        self.init_mod(self.block)
+        init_mod(self.block)
 
         self.res_connect = None
         if residual_connect:
             if n_inputs != n_outputs:
                 self.res_connect = nn.Conv1d(n_inputs, n_outputs, kernel_size=1)
-                self.init_mod(self.res_connect)
+                init_mod(self.res_connect)
             else:
                 self.res_connect = nn.Identity()
-
-    @staticmethod
-    def init_mod(mod):
-        for name, parameters in mod.named_parameters():
-            if 'weight' in name:
-                nn.init.normal_(parameters)
-            elif 'bias' in name:
-                nn.init.zeros_(parameters)
 
     def forward(self, x):
         x = x.transpose(1, 2)
@@ -272,3 +256,15 @@ class ConvBlock(nn.Module):
             out = out + res
         out = out.transpose(1, 2)
         return out
+
+
+def init_mod(mod):
+    for name, parameters in mod.named_parameters():
+        if 'weight' in name:
+            # nn.init.normal_(parameters)
+            try:
+                nn.init.kaiming_uniform_(parameters)
+            except:
+                nn.init.normal_(parameters)
+        elif 'bias' in name:
+            nn.init.zeros_(parameters)

--- a/env/env_user.py
+++ b/env/env_user.py
@@ -9,7 +9,7 @@ import os
 project_dir = os.path.expanduser('~/projects/KnowIt/')
 
 # where to find Knowit scripts
-repo_dir = os.path.expanduser('~/Dev/KnowIt')
+repo_dir = os.path.expanduser('~/g_repos/KnowIt')
 
 dataset_dir = os.path.join(repo_dir, 'datasets')
 archs_dir = os.path.join(repo_dir, 'archs')

--- a/environment.yml
+++ b/environment.yml
@@ -1,158 +1,165 @@
 name: knowit_env
 channels:
+  - anaconda
   - pytorch
   - nvidia
   - conda-forge
-  - anaconda
   - defaults
 dependencies:
   - _libgcc_mutex=0.1=main
-  - _openmp_mutex=4.5=1_gnu
+  - _openmp_mutex=5.1=1_gnu
   - alabaster=0.7.12=pyhd3eb1b0_0
-  - astroid=2.11.3=py38h578d9bd_0
-  - attrs=20.2.0=py_0
-  - babel=2.9.1=pyhd3eb1b0_0
+  - astroid=2.14.2=py38h06a4308_0
+  - attrs=23.1.0=py38h06a4308_0
+  - babel=2.11.0=py38h06a4308_0
   - blas=1.0=mkl
   - boost-cpp=1.74.0=h9359b55_0
-  - bottleneck=1.3.4=py38hce1f21e_0
+  - bottleneck=1.3.5=py38h7deecbd_0
+  - brotli-python=1.0.9=py38h6a678d5_7
   - brotlipy=0.7.0=py38h27cfd23_1003
   - bzip2=1.0.8=h7b6447c_0
   - ca-certificates=2023.08.22=h06a4308_0
   - certifi=2023.7.22=py38h06a4308_0
-  - cffi=1.15.0=py38hd667e15_1
+  - cffi=1.15.1=py38h5eee18b_3
   - cgal-cpp=5.0.3=h764656a_1
   - charset-normalizer=2.0.4=pyhd3eb1b0_0
-  - click=8.0.4=py38h06a4308_0
-  - colorama=0.4.4=pyhd3eb1b0_0
+  - click=8.1.7=py38h06a4308_0
+  - colorama=0.4.6=py38h06a4308_0
   - configparser=5.0.2=pyhd3eb1b0_0
-  - cryptography=36.0.0=py38h9ce1e76_0
+  - cryptography=41.0.3=py38hdda0065_0
   - cuda-cudart=11.8.89=0
   - cuda-cupti=11.8.87=0
   - cuda-libraries=11.8.0=0
   - cuda-nvrtc=11.8.89=0
   - cuda-nvtx=11.8.86=0
   - cuda-runtime=11.8.0=0
-  - cudatoolkit=10.2.89=hfd86e86_1
+  - cudatoolkit=11.8.0=h6a678d5_0
   - cycler=0.11.0=pyhd3eb1b0_0
-  - dill=0.3.4=pyhd8ed1ab_0
+  - dill=0.3.7=py38h06a4308_0
   - docker-pycreds=0.4.0=pyhd3eb1b0_0
-  - docutils=0.17.1=py38h06a4308_1
+  - docutils=0.18.1=py38h06a4308_3
   - eigen=3.3.7=hd09550d_1
+  - exceptiongroup=1.0.4=py38h06a4308_0
   - ffmpeg=4.2.2=h20bf706_0
   - filelock=3.9.0=py38h06a4308_0
-  - freetype=2.11.0=h70c0345_0
-  - giflib=5.2.1=h7b6447c_0
+  - freetype=2.12.1=h4a9f257_0
+  - giflib=5.2.1=h5eee18b_3
   - gitdb=4.0.7=pyhd3eb1b0_0
-  - gitpython=3.1.18=pyhd3eb1b0_1
-  - gmp=6.2.1=h2531618_2
+  - gitpython=3.1.37=py38h06a4308_0
+  - gmp=6.2.1=h295c915_3
   - gmpy2=2.1.2=py38heeb90bb_0
   - gnutls=3.6.15=he1e5248_0
   - icu=67.1=he1b5a44_0
-  - idna=3.3=pyhd3eb1b0_0
-  - imagesize=1.3.0=pyhd3eb1b0_0
-  - importlib-metadata=4.11.3=py38h06a4308_0
-  - importlib_metadata=4.11.3=hd8ed1ab_1
-  - iniconfig=1.1.1=py_0
+  - idna=3.4=py38h06a4308_0
+  - imagesize=1.4.1=py38h06a4308_0
+  - importlib-metadata=6.0.0=py38h06a4308_0
+  - importlib_metadata=6.0.0=hd3eb1b0_0
+  - iniconfig=1.1.1=pyhd3eb1b0_0
   - intel-openmp=2021.4.0=h06a4308_3561
-  - isort=5.10.1=pyhd8ed1ab_0
-  - jinja2=3.0.3=pyhd3eb1b0_0
-  - joblib=1.1.0=pyhd3eb1b0_0
-  - jpeg=9d=h7f8727e_0
-  - kiwisolver=1.3.2=py38h295c915_0
+  - isort=5.9.3=pyhd3eb1b0_0
+  - jinja2=3.1.2=py38h06a4308_0
+  - joblib=1.2.0=py38h06a4308_0
+  - jpeg=9e=h5eee18b_1
+  - kiwisolver=1.4.4=py38h6a678d5_0
   - lame=3.100=h7b6447c_0
   - lazy-object-proxy=1.6.0=py38h27cfd23_0
   - lcms2=2.12=h3be6417_0
-  - ld_impl_linux-64=2.35.1=h7274673_9
+  - ld_impl_linux-64=2.38=h1181459_1
   - libcublas=11.11.3.6=0
   - libcufft=10.9.0.58=0
   - libcufile=1.7.2.10=0
   - libcurand=10.3.3.141=0
   - libcusolver=11.4.1.48=0
   - libcusparse=11.7.5.86=0
-  - libffi=3.3=he6710b0_2
-  - libgcc-ng=9.3.0=h5101ec6_17
+  - libffi=3.4.4=h6a678d5_0
+  - libgcc-ng=11.2.0=h1234567_1
   - libgfortran-ng=7.5.0=ha8ba4b0_17
   - libgfortran4=7.5.0=ha8ba4b0_17
-  - libgomp=9.3.0=h5101ec6_17
-  - libidn2=2.3.2=h7f8727e_0
+  - libgomp=11.2.0=h1234567_1
+  - libidn2=2.3.4=h5eee18b_0
+  - libjpeg-turbo=2.0.0=h9bf148f_0
   - libnpp=11.8.0.86=0
   - libnvjpeg=11.9.0.86=0
   - libopus=1.3.1=h7b6447c_0
-  - libpng=1.6.37=hbc83047_0
-  - libprotobuf=3.19.1=h4ff587b_0
-  - libstdcxx-ng=9.3.0=hd4cf53a_17
-  - libtasn1=4.16.0=h27cfd23_0
+  - libpng=1.6.39=h5eee18b_0
+  - libprotobuf=3.20.3=he621ea3_0
+  - libstdcxx-ng=11.2.0=h1234567_1
+  - libtasn1=4.19.0=h5eee18b_0
   - libtiff=4.2.0=h85742a9_0
   - libunistring=0.9.10=h27cfd23_0
-  - libuv=1.40.0=h7b6447c_0
+  - libuv=1.44.2=h5eee18b_0
   - libvpx=1.7.0=h439df22_0
-  - libwebp=1.2.2=h55f646e_0
-  - libwebp-base=1.2.2=h7f8727e_0
-  - lz4-c=1.9.3=h295c915_1
-  - markupsafe=2.0.1=py38h27cfd23_0
+  - libwebp=1.3.2=h11a3e52_0
+  - libwebp-base=1.3.2=h5eee18b_0
+  - lightning-utilities=0.9.0=py38h06a4308_0
+  - llvm-openmp=14.0.6=h9e868ea_0
+  - lz4-c=1.9.4=h6a678d5_0
+  - markupsafe=2.1.1=py38h7f8727e_0
   - matplotlib=3.2.2=1
   - matplotlib-base=3.2.2=py38h5d868c9_1
-  - mccabe=0.7.0=pyhd8ed1ab_0
+  - mccabe=0.7.0=pyhd3eb1b0_0
   - mkl=2021.4.0=h06a4308_640
   - mkl-service=2.4.0=py38h7f8727e_0
   - mkl_fft=1.3.1=py38hd3c417c_0
   - mkl_random=1.2.2=py38h51133e4_0
-  - more-itertools=8.5.0=py_0
+  - more-itertools=8.12.0=pyhd3eb1b0_0
   - mpc=1.1.0=h10f8cd9_1
   - mpfr=4.0.2=hb69a4c5_1
   - mpmath=1.3.0=py38h06a4308_0
-  - ncurses=6.3=h7f8727e_2
+  - ncurses=6.4=h6a678d5_0
   - nettle=3.7.3=hbbd107a_1
   - networkx=3.1=py38h06a4308_0
   - nlopt=2.7.0=py38h6599729_1
-  - numexpr=2.8.1=py38h6abb31d_0
-  - numpy=1.21.5=py38he7a7128_1
-  - numpy-base=1.21.5=py38hf524024_1
+  - numexpr=2.8.4=py38he184ba9_0
+  - numpy=1.24.3=py38h14f4228_0
+  - numpy-base=1.24.3=py38h31eccc5_0
   - openh264=2.1.1=h4ff587b_0
-  - openssl=1.1.1w=h7f8727e_0
-  - packaging=21.3=pyhd3eb1b0_0
+  - openjpeg=2.4.0=h3ad879b_0
+  - openssl=3.0.11=h7f8727e_2
+  - packaging=23.1=py38h06a4308_0
   - pandas=1.4.2=py38h295c915_0
   - pathtools=0.1.2=pyhd3eb1b0_1
-  - pillow=9.0.1=py38h22f2fdc_0
-  - pip=21.2.4=py38h06a4308_0
-  - platformdirs=2.5.1=pyhd8ed1ab_0
-  - pluggy=0.13.1=py38_0
+  - pillow=10.0.1=py38ha6cbd5a_0
+  - pip=23.3=py38h06a4308_0
+  - platformdirs=3.10.0=py38h06a4308_0
+  - pluggy=1.0.0=py38h06a4308_1
   - pockets=0.9.1=py_0
   - promise=2.3=py38h06a4308_0
-  - protobuf=3.19.1=py38h295c915_0
-  - psutil=5.8.0=py38h27cfd23_1
-  - py=1.9.0=py_0
+  - protobuf=3.20.3=py38h6a678d5_0
+  - psutil=5.9.0=py38h5eee18b_0
+  - py=1.11.0=pyhd3eb1b0_0
   - pycparser=2.21=pyhd3eb1b0_0
-  - pygments=2.11.2=pyhd3eb1b0_0
-  - pylint=2.13.7=pyhd8ed1ab_0
+  - pygments=2.15.1=py38h06a4308_1
+  - pylint=2.16.2=py38h06a4308_0
   - pynput=1.7.3=py38h578d9bd_0
-  - pyopenssl=22.0.0=pyhd3eb1b0_0
-  - pyparsing=3.0.4=pyhd3eb1b0_0
+  - pyopenssl=23.2.0=py38h06a4308_0
+  - pyparsing=3.0.9=py38h06a4308_0
   - pysocks=1.7.1=py38h06a4308_0
-  - pytest=6.1.1=py38_0
-  - python=3.8.13=h12debd9_0
+  - pytest=7.4.0=py38h06a4308_0
+  - python=3.8.18=h955ad1f_0
   - python-dateutil=2.8.2=pyhd3eb1b0_0
   - python-xlib=0.28=pyh9f0ad1d_0
   - python_abi=3.8=2_cp38
-  - pytorch=2.0.1=py3.8_cuda11.8_cudnn8.7.0_0
+  - pytorch=2.1.0=py3.8_cuda11.8_cudnn8.7.0_0
   - pytorch-cuda=11.8=h7e8668a_5
+  - pytorch-lightning=2.0.3=py38h06a4308_0
   - pytorch-mutex=1.0=cuda
-  - pytz=2021.3=pyhd3eb1b0_0
-  - pyyaml=6.0=py38h7f8727e_1
-  - readline=8.1.2=h7f8727e_1
-  - requests=2.27.1=pyhd3eb1b0_0
+  - pytz=2023.3.post1=py38h06a4308_0
+  - pyyaml=6.0.1=py38h5eee18b_0
+  - readline=8.2=h5eee18b_0
+  - requests=2.31.0=py38h06a4308_0
   - scikit-geometry=0.1.2=py38he18db2a_4
-  - scikit-learn=1.0.2=py38h51133e4_1
+  - scikit-learn=1.3.0=py38h1128e8f_0
   - scipy=1.7.3=py38hc147768_0
-  - sentry-sdk=1.5.9=pyhd8ed1ab_0
+  - sentry-sdk=1.9.0=py38h06a4308_0
   - setproctitle=1.2.2=py38h27cfd23_1004
-  - setuptools=61.2.0=py38h06a4308_0
+  - setuptools=68.0.0=py38h06a4308_0
   - setuptools-lint=0.6.0=pyh9f0ad1d_0
   - shortuuid=1.0.8=py38h578d9bd_0
   - six=1.16.0=pyhd3eb1b0_1
   - smmap=4.0.0=pyhd3eb1b0_0
   - snowballstemmer=2.2.0=pyhd3eb1b0_0
-  - sphinx=4.4.0=pyhd3eb1b0_0
+  - sphinx=5.0.2=py38h06a4308_0
   - sphinxcontrib-applehelp=1.0.2=pyhd3eb1b0_0
   - sphinxcontrib-devhelp=1.0.2=pyhd3eb1b0_0
   - sphinxcontrib-htmlhelp=2.0.0=pyhd3eb1b0_0
@@ -160,27 +167,30 @@ dependencies:
   - sphinxcontrib-napoleon=0.7=py_0
   - sphinxcontrib-qthelp=1.0.3=pyhd3eb1b0_0
   - sphinxcontrib-serializinghtml=1.1.5=pyhd3eb1b0_0
-  - sqlite=3.38.2=hc218d9a_0
+  - sqlite=3.41.2=h5eee18b_0
   - sympy=1.11.1=py38h06a4308_0
   - threadpoolctl=2.2.0=pyh0d69192_0
-  - tk=8.6.11=h1ccaba5_0
-  - toml=0.10.1=py_0
-  - tomli=2.0.1=pyhd8ed1ab_0
-  - torchaudio=2.0.2=py38_cu118
-  - torchtriton=2.0.0=py38
-  - torchvision=0.15.2=py38_cu118
-  - tornado=6.1=py38h27cfd23_0
-  - typing-extensions=4.1.1=hd3eb1b0_0
-  - typing_extensions=4.1.1=pyh06a4308_0
-  - urllib3=1.26.8=pyhd3eb1b0_0
+  - tk=8.6.12=h1ccaba5_0
+  - toml=0.10.2=pyhd3eb1b0_0
+  - tomli=2.0.1=py38h06a4308_0
+  - tomlkit=0.11.1=py38h06a4308_0
+  - torchaudio=2.1.0=py38_cu118
+  - torchmetrics=0.11.4=py38h2f386ee_1
+  - torchtriton=2.1.0=py38
+  - torchvision=0.16.0=py38_cu118
+  - tornado=6.3.3=py38h5eee18b_0
+  - tqdm=4.65.0=py38hb070fc8_0
+  - typing-extensions=4.7.1=py38h06a4308_0
+  - typing_extensions=4.7.1=py38h06a4308_0
+  - urllib3=1.26.18=py38h06a4308_0
   - wandb=0.12.14=pyhd8ed1ab_0
-  - wheel=0.37.1=pyhd3eb1b0_0
+  - wheel=0.41.2=py38h06a4308_0
   - wrapt=1.11.2=py38h1e0a361_1
   - x264=1!157.20191217=h7b6447c_0
-  - xz=5.2.5=h7b6447c_0
+  - xz=5.4.2=h5eee18b_0
   - yaml=0.2.5=h7b6447c_0
-  - zipp=3.7.0=pyhd3eb1b0_0
-  - zlib=1.2.11=h7f8727e_4
+  - zipp=3.11.0=py38h06a4308_0
+  - zlib=1.2.13=h5eee18b_0
   - zstd=1.4.9=haebb681_0
   - pip:
       - cloudpickle==2.0.0

--- a/trainer/train_examples.py
+++ b/trainer/train_examples.py
@@ -4,7 +4,8 @@ from data.base_dataset import BaseDataset
 from trainer import KITrainer
 
 from archs.MLP import Model
-#from archs.TCN import Model
+# from archs.TCN import Model
+# from archs.CNN import Model
 
 import torch
 from torchmetrics import F1Score, Accuracy
@@ -139,7 +140,7 @@ def main():
                                            in_components=['x1', 'x2', 'x3', 'x4'],
                                            out_components=['y1', 'y2'], in_chunk=[-5, 5], out_chunk=[0, 0],
                                            split_portions=(0.6, 0.2, 0.2), seed=666, batch_size=64, limit=None,
-                                           min_slice=10, scaling_method='zero-one', scaling_tag='full',
+                                           min_slice=10, scaling_method='z-norm', scaling_tag='full',
                                            split_method='slice-random')
     
     trainer_loader = datamodule.get_dataloader('train')

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -35,11 +35,11 @@ import torchmetrics
 from torch import nn
 from torch.nn import functional as F
 
-import lightning.pytorch as pl
-from lightning.pytorch import loggers as pl_loggers
-from lightning.pytorch.callbacks.early_stopping import EarlyStopping
-from lightning.pytorch.callbacks import ModelCheckpoint
-from lightning.pytorch import seed_everything
+import pytorch_lightning as pl
+from pytorch_lightning import loggers as pl_loggers
+from pytorch_lightning.callbacks.early_stopping import EarlyStopping
+from pytorch_lightning.callbacks import ModelCheckpoint
+from pytorch_lightning import seed_everything
 
 class PLModel(pl.LightningModule):
     
@@ -59,8 +59,8 @@ class PLModel(pl.LightningModule):
         self.model = model
         self.performance_metrics = performance_metrics
         
-        #self.save_hyperparameters(ignore=["model"])
-        self.save_hyperparameters()
+        self.save_hyperparameters(ignore=["model"])
+        # self.save_hyperparameters()
         
     def __get_loss_function(self, loss):
         """Helper method to retrieve user's choice of loss function."""


### PR DESCRIPTION
1. Fixes some issues regarding initialization and exploding gradient with TCN and CNN archs. Not completely solved but better.
2. Updated environment.yml. All packages are updated to latest (including pytorch 2.0.1 to 2.1.0).
3. Trainer now ignores 'model' as an HP to save. This breaks if the model uses submodules that cannot be deepcopied (like weight norm layers). To discuss. 
4. Also changed the import method in trainer.py to match latest versions. I think we all need to work on the latest versions of these packages. To discuss if needed.