### PR TITLE
Importing direct dataframe and datasets with very large number of instances/slices now allowed

### DIFF
--- a/data/base_dataset.py
+++ b/data/base_dataset.py
@@ -165,6 +165,51 @@ class BaseDataset:
         return DataExtractor(self.package_path, self.components, self.instance_names, self.data_structure)
 
     @classmethod
+    def from_raw(cls, exp_output_dir: str,
+                  raw_data: str | DataFrame, safe_mode: bool,
+                  base_nan_filler: str | None,
+                  nan_filled_components: list | None,
+                  meta: dict | None) -> data.BaseDataset:
+        """Instantiate a BaseDataset object from raw data, either a file path or a DataFrame.
+
+        Parameters
+        ----------
+        exp_output_dir : str
+            The directory path for experiment output.
+        raw_data : str | DataFrame
+            Either a file path to the raw data or a pandas DataFrame containing the raw data.
+        safe_mode : bool
+            A flag indicating whether to operate in safe mode.
+        base_nan_filler : str | None
+            The method used to fill NaNs in the base dataset.
+        nan_filled_components : list | None
+            A list of components in the dataset that should have NaNs filled.
+        meta : dict | None
+            A dictionary containing the required metadata or None.
+            If None, metadata should be provided in file at path.
+
+        Returns
+        -------
+        data.BaseDataset
+            An instance of the BaseDataset class initialized with the provided raw data.
+
+        Notes
+        -----
+        - If `raw_data` is a string, it is treated as a file path and processed via `BaseDataset.from_path`.
+        - If `raw_data` is a pandas DataFrame, it is processed via `BaseDataset.from_df`.
+        - The method delegates to appropriate class methods based on the type of `raw_data`.
+
+        """
+        if isinstance(raw_data, str):
+            return cls.from_path(exp_output_dir, raw_data, safe_mode, base_nan_filler, nan_filled_components, meta)
+        elif isinstance(raw_data, DataFrame):
+            return cls.from_df(raw_data, exp_output_dir, safe_mode, base_nan_filler, nan_filled_components, meta)
+        else:
+            logger.error('Unknown data import type %s. Aborting.', type(data))
+            exit(101)
+
+
+    @classmethod
     def from_path(cls, exp_output_dir: str,
                   path: str, safe_mode: bool,
                   base_nan_filler: str | None,

--- a/default_datasets/dataset_how_to.md
+++ b/default_datasets/dataset_how_to.md
@@ -4,9 +4,9 @@ This guide explains how to import and manage new raw data.
 ## 1. Importing new datasets using Pandas
 
 In order to train models on your data you will need to convert it into a specific format for 
-KnowIt to understand. Your data will need to be compiled into a pickled 
-[``pandas.Dataframe``](https://pandas.pydata.org/docs/reference/frame.html) that meets 
-a number of criteria. It can then be imported using the ``KnowIt.import_dataset(kwarg={'import_data_args': {'path': <path to pickle>, ...}})`` function.
+KnowIt to understand. Your data will need to be compiled into a [``pandas.Dataframe``](https://pandas.pydata.org/docs/reference/frame.html) that meets 
+a number of criteria. It can then be imported using the ``KnowIt.import_dataset(kwarg={'import_data_args': {'raw_data': <the dataframe>, ...}})`` function.
+You can also provide the data as a path to a pickled dataframe using ``KnowIt.import_dataset(kwarg={'import_data_args': {'raw_data': <path to pickle>, ...}})``.
 
 The criteria are as follows:
 1. Must be time indexed. (with a [``pandas.DatetimeIndex``](https://pandas.pydata.org/docs/reference/api/pandas.DatetimeIndex.html#pandas.DatetimeIndex), not strings)

--- a/helpers/file_dir_procs.py
+++ b/helpers/file_dir_procs.py
@@ -344,4 +344,10 @@ def safe_dump_parquet(path: str, safe_mode: bool, data_package: any,
     elif os.path.exists(path) and not safe_mode:
         logger.warning('Base dataset package already exists at {}, overwriting.'.format(path))
         shutil.rmtree(path)
-    data_package.to_parquet(path, engine=engine, partition_cols=partitioned_on)
+
+    num_fragments = data_package.groupby(partitioned_on).ngroups
+    if num_fragments > 1024:
+        logger.warning('Partitioning dataset into a parquet folder with %s fragments. '
+                       'Some overhead expected during data loading from disk.',
+                       num_fragments)
+    data_package.to_parquet(path, engine=engine, partition_cols=partitioned_on, max_partitions=num_fragments)

--- a/knowit.py
+++ b/knowit.py
@@ -305,7 +305,7 @@ class KnowIt:
         data_import = relevant_args['data_import']
         data_import['exp_output_dir'] = self.exp_output_dir
         data_import['safe_mode'] = safe_mode
-        return BaseDataset.from_path(**data_import)
+        return BaseDataset.from_raw(**data_import)
 
     def train_model(self, model_name: str, kwargs: dict, *, device: str | None = None,
                     safe_mode: bool | None = None, and_viz: bool | None = None,

--- a/setup/setup_action_args.py
+++ b/setup/setup_action_args.py
@@ -26,7 +26,7 @@ __description__ = 'Checks, filters, and adjusts user arguments for various actio
 from helpers.logger import get_logger
 logger = get_logger()
 
-arg_dict = {'data_import':  {'required': ('path',),
+arg_dict = {'data_import':  {'required': ('raw_data',),
                                   'optional': ('base_nan_filler',
                                                'nan_filled_components',
                                                'meta'),

--- a/tutorials/ETT_basics_tutorial/ETT_tut.md
+++ b/tutorials/ETT_basics_tutorial/ETT_tut.md
@@ -150,7 +150,7 @@ KI = KnowIt('ETT_exp_dir')
 # we switch KnowIt to verbose mode to provide more information
 KI.global_args(verbose=True)
 # import the prepared data into KnowIt
-KI.import_dataset({'data_import': {'path': 'ETT_ready.pkl'}})
+KI.import_dataset({'data_import': {'raw_data': 'ETT_ready.pkl'}})
 ```
 
 ### 3.2. Output

--- a/user_options.md
+++ b/user_options.md
@@ -22,7 +22,7 @@ and calls the ``KnowIt.import_dataset`` function with the relevant kwargs.
 ```python
 from knowit import KnowIt
 KI = KnowIt('/my_experiment_dir')
-import_args = {'path': '/my_new_raw_data.pickle',
+import_args = {'raw_data': '/my_new_raw_data.pickle',
                'base_nan_filler': 'linear',
                'nan_filled_components': ['x1', 'x2', 'x3']}
 KI.import_dataset(kwargs={'data_import': import_args})


### PR DESCRIPTION
This pull request adds two features:

1. The user can now import raw data as a dataframe directly in addition to the usual path-to-pickle-of-dataframe format. The main practical difference is that the use now defines a "raw_data" argument in the "import_data" kwargs instead of the "path" argument as in the past. This variable can either be a string (file path to pickle) or dataframe directly.
2. The storage of the base dataset can now handle a number of fragments (instance and slices) larger than the default limit of 1024 as defined in the pyarrow engine. The user is warned about possible increased overhead if the default limit is exceeded. 

This pull request addresses this issue: https://github.com/MUST-Deep-Learning/KnowIt/issues/193#issue-2981892703