### PR TITLE
Add custom data splits feature Issue #146

### DIFF
--- a/data/data_splitting.py
+++ b/data/data_splitting.py
@@ -238,9 +238,9 @@ class DataSplitter:
     def _custom_split(elements: array, split_category: array, limit: int, portions: tuple) -> tuple:
         """
         Splits an array of elements into train, valid, and eval sets based on the user defined split_category.
-        The train set constitutes elements with split_category '0'.
-        The valid set constitutes elements with split_category '1'.
-        The eval set constitutes elements with split_category '2'.
+        The train set constitutes elements with split_category int '0'.
+        The valid set constitutes elements with split_category int '1'.
+        The eval set constitutes elements with split_category int '2'.
 
         If the number of instances are limited, the split portions are used to limit each set accordingly.
 
@@ -261,9 +261,9 @@ class DataSplitter:
         Returns
         -------
         tuple
-            train_elements (array): The elements with split_category '0'.
-            valid_elements (array): The elements with split_category '1'.
-            eval_elements (array): The elements with split_category '2'.
+            train_elements (array): The elements with split_category int '0'.
+            valid_elements (array): The elements with split_category int '1'.
+            eval_elements (array): The elements with split_category int '2'.
         """
 
         train_elements = elements[where(split_category == 0)[0]]

--- a/data/data_splitting.py
+++ b/data/data_splitting.py
@@ -626,8 +626,10 @@ class DataSplitter:
         prediction_points = concatenate(prediction_points, axis=1)
         prediction_points = prediction_points.transpose()
         times = concatenate(times)
-        split_category = array(split_category)
-        # if split_category and ndim(split_category[0]) == 1:
-        #     split_category = concatenate(split_category)
+
+        if split_category and not load_level == 'instance':
+            split_category = concatenate(split_category)
+        else:
+            split_category = array(split_category)
 
         return prediction_points, times, split_category


### PR DESCRIPTION
Added a custom split function to the data_splitting module as indicated in Issue #146  . The split is defined by an extra column in the Dataframe labeled 'split' with integers indicating the category: Train: 0, Valid: 1, and Eval: 2. The necessary changes are made to the data_splitting module to accommodate this enhancement. The function is used when the user sets split_method = 'custom'. The splitting method only works for instances and not for timesteps or slices.