### PR TITLE
Added a custom split feature to address Issue #146

### DIFF
--- a/data/prepared_dataset.py
+++ b/data/prepared_dataset.py
@@ -279,7 +279,7 @@ class PreparedDataset(BaseDataset):
     out_shape = None
     class_set = None # only filled if task='classification'
     class_counts = None  # only filled if task='classification'
-    class_splits = None
+    custom_splits = None # only filled if custom_splits are defined at data import
 
     def __init__(self, **kwargs) -> None:
 

--- a/data/prepared_dataset.py
+++ b/data/prepared_dataset.py
@@ -239,7 +239,7 @@ class PreparedDataset(BaseDataset):
     class_counts : dict
         A dictionary that maps each class ID to its size.
         Only created if task='classification'.
-    class_splits: dict
+    custom_splits: dict
         A dictionary defining the custom selection matrices.
 
     Notes
@@ -537,23 +537,23 @@ class PreparedDataset(BaseDataset):
 
         # split the dataset
         logger.info('Preparing data splits (selection).')
-        if self.split_method != 'custom':
-            self.selection = DataSplitter(self.get_extractor(),
-                                          self.split_method,
-                                          self.split_portions,
-                                          self.limit, self.x_map, self.y_map,
-                                          self.in_chunk, self.out_chunk,
-                                          self.min_slice).get_selection()
-        elif self.custom_splits != None:
-            self.selection = self.custom_splits
-            missing_split_components = set(self.selection) - {'valid', 'train', 'eval'}
-            if len(missing_split_components) > 0:
-                logger.error('Defined set selection %s not in custom splits.',
-                             str(missing_out_components))
-                exit(101)
-        else:
-            logger.error('Custom splits not defined.')
-            exit(101)
+        self.selection = DataSplitter(self.get_extractor(),
+                                      self.split_method,
+                                      self.split_portions,
+                                      self.limit, self.x_map, self.y_map,
+                                      self.in_chunk, self.out_chunk,
+                                      self.min_slice,
+                                      custom_splits = self.custom_splits).get_selection()
+        # if self.split_method == 'custom':
+        #     self.selection = self.custom_splits
+        #     missing_split_components = set(self.selection) - {'valid', 'train', 'eval'}
+        #     if len(missing_split_components) > 0:
+        #         logger.error('Defined set selection %s not in custom splits.',
+        #                      str(missing_out_components))
+        #         exit(101)
+        # else:
+        #     logger.error('Custom splits not defined.')
+        #     exit(101)
 
         self.train_set_size = len(self.selection['train'])
         self.valid_set_size = len(self.selection['valid'])

--- a/data/prepared_dataset.py
+++ b/data/prepared_dataset.py
@@ -72,8 +72,8 @@ the excess data points from the end of the data block after shuffling or orderin
 Also note that if the data is limited too much for a given ``split_portion`` to have a single entry,
 an error will occur confirming it.
 
-Note that the 'custom' split have to be constructed during the importation of the dataset.
-This is done in data.raw_data_conversion.py
+Note that the 'custom' split has to be constructed during the data importing.
+See the RawDataConverter module for more information.
 
 -------
 Scaling
@@ -239,6 +239,8 @@ class PreparedDataset(BaseDataset):
     class_counts : dict
         A dictionary that maps each class ID to its size.
         Only created if task='classification'.
+    class_splits: dict
+        A dictionary defining the custom selection matrices.
 
     Notes
     -----
@@ -498,7 +500,7 @@ class PreparedDataset(BaseDataset):
             - The splits are defined in the 'selection' variable in three selection matrices.
             - The scalers are stored in the 'x_scaler' and 'y_scaler' variables.
             - After the data is prepared the 'the_data' dictionary is removed from memory.
-            - If 'custom' is used, the selection matrices are constructed by data.raw_data_conversion
+            - If custom splits are defined, the selection matrices are constructed by data.raw_data_conversion.
               which is used to indicate the set splits
 
         """

--- a/data/prepared_dataset.py
+++ b/data/prepared_dataset.py
@@ -62,7 +62,7 @@ More details can be found in ``DataSplitter``, but we summarize the options here
     - 'slice-chronological': Ignore all distinction between instances, and split on slices chronologically.
     - 'instance-random': Split on instances randomly.
     - 'instance-chronological': Split on instances chronologically.
-    - 'custom': User defined split on instances.
+    - 'custom': User defined split.
 Note that the data is split ON the relevant level (instance, slice, or timesteps).
 I.e. If you split on instances and there are only 3 instances, then split_portions=(0.6, 0.2, 0.2)
 will be a wild approximation i.t.o actual time steps.
@@ -72,12 +72,8 @@ the excess data points from the end of the data block after shuffling or orderin
 Also note that if the data is limited too much for a given ``split_portion`` to have a single entry,
 an error will occur confirming it.
 
-Note that to use the 'custom' split, a separate column must be defined in the dataframe labeled 'split'.
-This column contains the set indicators
-    - The train set is indicated by 0.
-    - The validation set is indicated by 1.
-    - The evaluation set is indicated by 2
-Once the dataset is imported with Knowit.import_dataset(), can the custom split be used.
+Note that the 'custom' split have to be constructed during the importation of the dataset.
+This is done in data.raw_data_conversion.py
 
 -------
 Scaling
@@ -281,6 +277,7 @@ class PreparedDataset(BaseDataset):
     out_shape = None
     class_set = None # only filled if task='classification'
     class_counts = None  # only filled if task='classification'
+    class_splits = None
 
     def __init__(self, **kwargs) -> None:
 
@@ -501,8 +498,8 @@ class PreparedDataset(BaseDataset):
             - The splits are defined in the 'selection' variable in three selection matrices.
             - The scalers are stored in the 'x_scaler' and 'y_scaler' variables.
             - After the data is prepared the 'the_data' dictionary is removed from memory.
-            - If 'custom' is used, a previously defined list created by data.raw_data_conversion
-            is used to indicate the set splits
+            - If 'custom' is used, the selection matrices are constructed by data.raw_data_conversion
+              which is used to indicate the set splits
 
         """
         # check that desired components are in dataset
@@ -545,7 +542,7 @@ class PreparedDataset(BaseDataset):
                                           self.limit, self.x_map, self.y_map,
                                           self.in_chunk, self.out_chunk,
                                           self.min_slice).get_selection()
-        elif hasattr(self, 'custom_splits'):
+        elif self.custom_splits != None:
             self.selection = self.custom_splits
             missing_split_components = set(self.selection) - {'valid', 'train', 'eval'}
             if len(missing_split_components) > 0:
@@ -553,8 +550,7 @@ class PreparedDataset(BaseDataset):
                              str(missing_out_components))
                 exit(101)
         else:
-            logger.error('The custom split dictionary does not exist. Import the dataset with '
-                         'Knowit.import_dataset to create the custom split dictionary')
+            logger.error('Custom splits not defined.')
             exit(101)
 
         self.train_set_size = len(self.selection['train'])

--- a/data/prepared_dataset.py
+++ b/data/prepared_dataset.py
@@ -183,7 +183,7 @@ class PreparedDataset(BaseDataset):
         The mini-batch size for training.
     split_method : str
         The method of splitting data. Options are 'random', 'chronological',
-        'instance-random', 'instance-chronological', 'slice-random', 'slice-chronological', or 'custom.
+        'instance-random', 'instance-chronological', 'slice-random', 'slice-chronological', or 'custom'.
         See heading for description.
     scaling_method : str | None
         The method for scaling data features. Options are 'z-norm', 'zero-one', or None.
@@ -500,8 +500,6 @@ class PreparedDataset(BaseDataset):
             - The splits are defined in the 'selection' variable in three selection matrices.
             - The scalers are stored in the 'x_scaler' and 'y_scaler' variables.
             - After the data is prepared the 'the_data' dictionary is removed from memory.
-            - If custom splits are defined, the selection matrices are constructed by data.raw_data_conversion.
-              which is used to indicate the set splits
 
         """
         # check that desired components are in dataset
@@ -544,16 +542,6 @@ class PreparedDataset(BaseDataset):
                                       self.in_chunk, self.out_chunk,
                                       self.min_slice,
                                       custom_splits = self.custom_splits).get_selection()
-        # if self.split_method == 'custom':
-        #     self.selection = self.custom_splits
-        #     missing_split_components = set(self.selection) - {'valid', 'train', 'eval'}
-        #     if len(missing_split_components) > 0:
-        #         logger.error('Defined set selection %s not in custom splits.',
-        #                      str(missing_out_components))
-        #         exit(101)
-        # else:
-        #     logger.error('Custom splits not defined.')
-        #     exit(101)
 
         self.train_set_size = len(self.selection['train'])
         self.valid_set_size = len(self.selection['valid'])

--- a/data/prepared_dataset.py
+++ b/data/prepared_dataset.py
@@ -541,7 +541,7 @@ class PreparedDataset(BaseDataset):
                                       self.limit, self.x_map, self.y_map,
                                       self.in_chunk, self.out_chunk,
                                       self.min_slice,
-                                      custom_splits = self.custom_splits).get_selection()
+                                      custom_splits=self.custom_splits).get_selection()
 
         self.train_set_size = len(self.selection['train'])
         self.valid_set_size = len(self.selection['valid'])

--- a/data/raw_data_coversion.py
+++ b/data/raw_data_coversion.py
@@ -28,7 +28,7 @@ If a custom data split is used it should be defined in a separate column in the 
 This column should contain the set indicators
     - The train set is indicated by 0.
     - The validation set is indicated by 1.
-    - The evaluation set is indicated by 2
+    - The evaluation set is indicated by 2.
 Appropriate selection matrices are generated and saved as metadata.
 Once the dataset is imported with Knowit.import_dataset(), the user can use this custom split.
 

--- a/data/raw_data_coversion.py
+++ b/data/raw_data_coversion.py
@@ -29,10 +29,10 @@ This column should contain the set indicators
     - The train set is indicated by 0.
     - The validation set is indicated by 1.
     - The evaluation set is indicated by 2
-The selection matrices are saved for future use.
-Once the dataset is imported with Knowit.import_dataset(), can the custom split be used.
+Appropriate selection matrices are generated and saved as metadata.
+Once the dataset is imported with Knowit.import_dataset(), the user can use this custom split.
 
-Note that the 'split' column should not be included as a component in the metadata
+Note that the 'split' column should not be included as a component in the metadata of the raw dataframe being imported.
 
 ---------
 Take note
@@ -148,7 +148,7 @@ class RawDataConverter:
                 - 'base_nan_filler': The method or value used to fill NaN values in the dataset.
                 - 'nan_filled_components': The components where potential NaN values were filled.
                 - 'data_structure': The structure of the dataset.
-                - 'custom_splits': Defines the custom data splits
+                - 'custom_splits': Defines the custom data splits if applicable.
                 - Additional metadata (e.g., name, components, time_delta).
 
         the_data : DataFrame

--- a/data/raw_data_coversion.py
+++ b/data/raw_data_coversion.py
@@ -20,7 +20,20 @@ Handling NaNs
     - nan_filled_components (str, None): Defines what components should be checked for NaNs.
         - None: All columns with float datatype will be flagged for NaN-handling.
         - A list of column headers to flag for NaN-handling.
-    
+
+------------
+Custom Split
+------------
+If a custom data split is used it should be defined in a separate column in the dataframe labeled 'split'.
+This column should contain the set indicators
+    - The train set is indicated by 0.
+    - The validation set is indicated by 1.
+    - The evaluation set is indicated by 2
+The selection matrices are saved for future use.
+Once the dataset is imported with Knowit.import_dataset(), can the custom split be used.
+
+Note that the 'split' column should not be included as a component in the metadata
+
 ---------
 Take note
 ---------

--- a/default_datasets/dataset_how_to.md
+++ b/default_datasets/dataset_how_to.md
@@ -18,11 +18,13 @@ The criteria are as follows:
 3. Must contain no all-NaN columns.
 4. Must contain column headers corresponding to the components defined in the metadata.
 
-
 If instances are desired, they must be defined in the metadata and a corresponding 
 column header 'instance' must be present in the dataframe. 
 This column contains no NaNs, and indicates what instance each time step (row) corresponds to.
 If no instances are define all time steps will be assumed to belong to one single instance.
+
+Similarly, if a custom data split is to be defined (for future training) it should be defined in a separate column in
+the dataframe labeled 'split'. This column should only contain set indicators: 0 (train), 1 (valid), or 2 (eval).
 
 The resulting datastructure will be stored under ``/custom_datasets`` in the relevant custom experiment output directory.
 It can then be used to train a model by passing ``kwargs={'data': {'name': <data name>, ...}, ...}`` when 


### PR DESCRIPTION
Added a custom split feature to address Issue #146. If a custom split column is detected in the dataframe when importing a custom dataset, a 'custom_splits' instance is created to define the different split sets. This instance is saved for use when selecting 'custom' as the split method. If 'custom' is selected as 'split_method' in 'data_args', this dictionary is used to define the splits instead of splitting the sets using another method. 