### PR TITLE
Epoch-wide performance metrics

### DIFF
--- a/data/raw_data_coversion.py
+++ b/data/raw_data_coversion.py
@@ -51,7 +51,7 @@ __description__ = 'Contains the RawDataConverter class for Knowit.'
 # external imports
 from pandas import DatetimeIndex, concat, DataFrame, Timedelta, to_datetime
 from pandas.api.types import is_numeric_dtype
-from numpy import array, sum, argwhere, hstack, vstack
+from numpy import array, sum, argwhere, hstack, vstack, expand_dims
 from datetime import timedelta
 
 # internal imports
@@ -189,21 +189,24 @@ class RawDataConverter:
                 if self.defines_custom_split:
                     instance_slice = new_df[['instance', 'slice']].values
 
-                    train_points = argwhere(self.the_data[i][s]['split'] == 0)
+                    train_points = argwhere(self.the_data[i][s]['split'] == 0).squeeze(axis=-1)
                     if len(train_points) > 0:
-                        train_ist = instance_slice[train_points.squeeze()]
+                        train_ist = instance_slice[train_points, :]
+                        train_points = expand_dims(train_points, axis=1)
                         train_ist = hstack((train_ist, train_points))
                         custom_splits['train'].extend(train_ist)
 
-                    valid_points = argwhere(self.the_data[i][s]['split'] == 1)
+                    valid_points = argwhere(self.the_data[i][s]['split'] == 1).squeeze(axis=-1)
                     if len(valid_points) > 0:
-                        valid_ist = instance_slice[valid_points.squeeze()]
+                        valid_ist = instance_slice[valid_points, :]
+                        valid_points = expand_dims(valid_points, axis=1)
                         valid_ist = hstack((valid_ist, valid_points))
                         custom_splits['valid'].extend(valid_ist)
 
-                    eval_points = argwhere(self.the_data[i][s]['split'] == 2)
+                    eval_points = argwhere(self.the_data[i][s]['split'] == 2).squeeze(axis=-1)
                     if len(eval_points) > 0:
-                        eval_ist = instance_slice[eval_points.squeeze()]
+                        eval_ist = instance_slice[eval_points, :]
+                        eval_points = expand_dims(eval_points, axis=1)
                         eval_ist = hstack((eval_ist, eval_points))
                         custom_splits['eval'].extend(eval_ist)
 

--- a/helpers/fetch_torch_mods.py
+++ b/helpers/fetch_torch_mods.py
@@ -17,54 +17,14 @@ import torch
 from torch import optim
 from torch.nn import functional as f
 from torch.optim import lr_scheduler
-from torchmetrics import functional as mf
+import torchmetrics as tm
 import pandas as pd
 
 from helpers.logger import get_logger
 logger = get_logger()
 
-def get_loss_function(loss: str) -> Callable[..., float | Tensor]:
-    """Return user's choice of loss function.
-
-    A helper method to retrieve the user's choice of loss function. The loss
-    function name must be the functional version from Pytorch's torch.nn
-    module.
-
-    Args:
-    ----
-        loss (str):         The loss function as specified in
-                            torch.nn.functional.
-
-    Returns
-    -------
-        (Callable):         A Pytorch loss function. Takes as input either
-                            two integers/floats and an optional dictionary of
-                            kwargs. Returns an integer/float value.
-
-    """
-    return getattr(f, loss)
-
-
-def get_performance_metric(metric: str) -> Callable[..., float | Tensor]:
-    """Return user's choice of performance metrics.
-
-    A helper method to retrieve the user's choice of performance metrics. The
-    metrics is the functional version from torchmetrics.
-
-    Args:
-    ----
-        metric (str):       The metric as specified in Torchmetrics. The metric
-                            name must be the functional version.
-
-    Returns
-    -------
-        (Callable):         A Torchmetrics metric function. Takes as input
-                            either two integers/floats and an optional
-                            dictionary of kwargs. Returns an integer/float
-                            value.
-
-    """
-    return getattr(mf, metric)
+ARGMAX_METRICS = {"Accuracy", "Precision", "Recall", "F1Score", "AUROC", "accuracy", "f1_score", "precision", "recall"}
+FLATTEN_METRICS = {"R2Score": (0, 1),}
 
 
 def get_optim(
@@ -109,80 +69,82 @@ def get_lr_scheduler(
     return getattr(lr_scheduler, scheduler)
 
 
-def prepare_function(user_args: str | dict[str, Any], *, is_loss: bool) -> (
-        dict[str, tuple[Callable[..., float | Tensor], bool]]
-    ):
-        """Set up and return a user's choice of function along with OHE requirement.
+def prepare_functions(user_args: str | dict[str, Any], is_loss: bool) -> dict:
+    """Set up and return a user's choice of functions along with configuration requirements.
 
-        Unpacks user_args and fetches the correct functions with any kwargs.
-        This is only performed once during the training run.
+    Unpacks user_args and fetches the correct functions with any kwargs.
+    This is only performed once during the training run.
+    Loss functions are found in `torch.nn.functional`, otherwise found in `torchmetrics`.
 
-        Parameters
-        ----------
-        user_args : str | dict[str, Any]
-            User-specified arguments for the function, either as a string or a dictionary.
-        is_loss : bool
-            Flag indicating whether to prepare a loss function or a performance metric.
+    Parameters
+    ----------
+    user_args : str | dict[str, Any]
+        User-specified arguments for the function, either as a string or a dictionary.
 
-        Returns
-        -------
-        dict
-            functions (dict): A dictionary where each key is a metric name and each value is a tuple
-                              containing a prepared function suitable for a task in the trainer module
-                              and a boolean indicating whether one-hot encoding is required for the function.
+    Returns
+    -------
+    dict
+        functions (dict): A dictionary where each key is a metric name and each value is a tuple
+                          containing a prepared function suitable for a task in the trainer module
+                          and required configurations for the metric.
 
-        """
-        function: dict[str, Callable[..., float|Tensor]] = {}
-        if is_loss and isinstance(user_args, dict):
-            for _metric in user_args:
-                kwargs = user_args[_metric]
-                loss_f = partial(
-                    get_loss_function(_metric),
-                    **kwargs,
-                )
-                function[_metric] = (loss_f, requires_argmax(_metric), requires_flatten(_metric))
-        elif is_loss and not isinstance(user_args, dict):
-                loss_f = get_loss_function(user_args)
-                function[user_args] = (loss_f, requires_argmax(user_args), requires_flatten(user_args))
-        elif not is_loss and isinstance(user_args, dict):
-            for _metric in user_args:
-                kwargs = user_args[_metric]
-                perf_f = partial(
-                    get_performance_metric(_metric),
-                    **kwargs,
-                )
-                function[_metric] = (perf_f, requires_argmax(_metric), requires_flatten(_metric))
-        elif not is_loss and not isinstance(user_args, dict):
-                perf_f = get_performance_metric(user_args)
-                function[user_args] = (perf_f, requires_argmax(user_args), requires_flatten(user_args))
+    """
+    functions = {}
+    if isinstance(user_args, dict):
+        for _metric in user_args:
+            kwargs = user_args[_metric]
+            if is_loss:
+                loss_f_cls = getattr(f, _metric)
+                loss_f = loss_f_cls(**kwargs)
+                # loss_f = partial(getattr(f, _metric), **kwargs)
+            else:
+                loss_f_cls = getattr(tm, _metric)
+                loss_f = loss_f_cls(**kwargs)
+                # loss_f = partial(getattr(tm, _metric), **kwargs)
 
-        return function
+            loss_f.requires_argmax = requires_argmax(_metric)
+            loss_f.requires_flatten = requires_flatten(_metric)
+            functions[_metric] = loss_f
+
+    else:
+        if is_loss:
+            loss_f = getattr(f, user_args)
+        else:
+            loss_f = getattr(tm, user_args)
+            loss_f = loss_f(**{})
+
+        loss_f.requires_argmax = requires_argmax(user_args)
+        loss_f.requires_flatten = requires_flatten(user_args)
+        functions[user_args] = loss_f
+
+    return functions
+
 
 def requires_argmax(metric: str) -> bool:
     """ Returns a bool indicating whether the defined metric requires
-    that the targets be argmaxed.
+    that the predictions and targets be argmaxed.
 
     See the following link for details on additional metrics that might need to be added
     to this list in the future:
     https://lightning.ai/docs/torchmetrics/stable/
     """
 
-    if metric in ("accuracy", ):
+    if metric in ARGMAX_METRICS:
         return True
     else:
         return False
 
 def requires_flatten(metric: str) -> tuple:
     """ Returns a tuple indicating whether the defined metric requires
-    that the targets be flattened along with from-to-what dimensions to flatten.
+    that the predictions and targets be flattened along with from-to-what dimensions to flatten.
 
     See the following link for details on additional metrics that might need to be added
     to this list in the future:
     https://lightning.ai/docs/torchmetrics/stable/
     """
 
-    if metric in ("r2_score", ):
-        return True, (0, 1)
+    if metric in FLATTEN_METRICS:
+        return True, FLATTEN_METRICS[metric]
     else:
         return False, None
 

--- a/helpers/fetch_torch_mods.py
+++ b/helpers/fetch_torch_mods.py
@@ -20,8 +20,25 @@ from pandas import read_csv
 from helpers.logger import get_logger
 logger = get_logger()
 
+# ARGMAX_METRICS and FLATTEN_METRICS define which metrics require special tensor transformations
+# before being passed to the metric function. When adding new entries, keep the following in mind:
+#
+# 1. Always add both the PascalCase OO name (e.g., "F1Score") and the snake_case functional
+#    equivalent (e.g., "f1_score") as separate explicit entries. The case-insensitive fallback
+#    lookup will handle arbitrary casing variants (e.g., "f1score"), but it cannot bridge
+#    the underscore gap between "f1score" and "f1_score".
+#
+# 2. For FLATTEN_METRICS, each entry maps a metric name to a (start_dim, end_dim) tuple
+#    indicating which dimensions to flatten via Tensor.flatten().
+#
+# 3. Be cautious with metrics whose OO and functional names do not follow the standard
+#    snake_case <-> PascalCase convention (e.g., "AUROC" vs "auroc"). These may require
+#    additional explicit entries or a custom mapping in _build_fn.
+#
+# See https://lightning.ai/docs/torchmetrics/stable/ for a full list of available metrics.
+
 ARGMAX_METRICS = {"Accuracy", "Precision", "Recall", "F1Score", "AUROC", "accuracy", "f1_score", "precision", "recall"}
-FLATTEN_METRICS = {"R2Score": (0, 1)}
+FLATTEN_METRICS = {"R2Score": (0, 1), "r2_score": (0, 1)}
 
 @dataclass
 class PreparedFunction:
@@ -146,6 +163,11 @@ def _build_fn(name: str, kwargs: dict, is_loss: bool) -> Any:
     these functions accept their arguments at call time rather than construction
     time. Torchmetrics classes are instantiated with ``**kwargs``.
 
+    If the metric name is not found directly on ``torchmetrics``, a second
+    attempt is made using the PascalCase translation of the name, to support
+    users who specify metrics using the ``torchmetrics.functional``
+    snake_case naming convention.
+
     Parameters
     ----------
     name : str
@@ -166,7 +188,20 @@ def _build_fn(name: str, kwargs: dict, is_loss: bool) -> Any:
     if is_loss:
         fn = getattr(F, name)
         return functools.partial(fn, **kwargs) if kwargs else fn
-    return getattr(torchmetrics, name)(**kwargs)
+
+    if hasattr(torchmetrics, name):
+        return getattr(torchmetrics, name)(**kwargs)
+
+    pascal_name = _to_pascal_case(name)
+    if hasattr(torchmetrics, pascal_name):
+        logger.warning(
+            f"Metric '{name}' not found in torchmetrics. "
+            f"Falling back to '{pascal_name}'."
+        )
+        return getattr(torchmetrics, pascal_name)(**kwargs)
+
+    logger.error(f"Metric '{name}' could not be resolved in torchmetrics.")
+    exit(101)
 
 
 def _wrap(name: str, fn: Any) -> PreparedFunction:
@@ -192,6 +227,22 @@ def _wrap(name: str, fn: Any) -> PreparedFunction:
         requires_flatten=_requires_flatten,
         flatten_dims=_flatten_dims,
     )
+
+
+def _to_pascal_case(name: str) -> str:
+    """Convert a snake_case string to PascalCase.
+
+    Parameters
+    ----------
+    name : str
+        A snake_case string (e.g., ``"mean_absolute_percentage_error"``).
+
+    Returns
+    -------
+    str
+        The PascalCase equivalent (e.g., ``"MeanAbsolutePercentageError"``).
+    """
+    return "".join(word.capitalize() for word in name.split("_"))
 
 
 def requires_argmax(metric: str) -> bool:

--- a/helpers/fetch_torch_mods.py
+++ b/helpers/fetch_torch_mods.py
@@ -1,174 +1,287 @@
 from __future__ import annotations  # noqa: D100
 __copyright__ = 'Copyright (c) 2025 North-West University (NWU), South Africa.'
 __licence__ = 'Apache 2.0; see LICENSE file for details.'
-__author__ = "randlerabe@gmail.com"
-__description__ = "Helper functions used in KnowIt's trainer module."
+__author__ = "randlerabe@gmail.com, tiantheunissen@gmail.com"
+__description__ = "Helper functions used when loading and configuring Pytorch or Torchmetrics modules and functions."
 
-
-from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Iterator
-
-if TYPE_CHECKING:
-    from torch import Tensor
-
+# standard library imports
+from dataclasses import dataclass
+from typing import Any
 import os
+import functools
 
+# external imports
 import torch
-from torch import optim
-from torch.nn import functional as f
-from torch.optim import lr_scheduler
-import torchmetrics as tm
-import pandas as pd
+import torch.nn.functional as F
+import torchmetrics
+from pandas import read_csv
 
+# internal imports
 from helpers.logger import get_logger
 logger = get_logger()
 
 ARGMAX_METRICS = {"Accuracy", "Precision", "Recall", "F1Score", "AUROC", "accuracy", "f1_score", "precision", "recall"}
-FLATTEN_METRICS = {"R2Score": (0, 1),}
+FLATTEN_METRICS = {"R2Score": (0, 1)}
 
+@dataclass
+class PreparedFunction:
+    """Container for a prepared loss function or performance metric.
 
-def get_optim(
-    optimizer: str,
-) -> type[tuple[Callable[[], Iterator[bool]], float, None | dict[str, Any]]]:
-    """Return user's choice of optimizer.
-
-    A helper method to retrieve the user's choice of optimizer.
-
-    Args:
-    ----
-        optimizer (str):    The optimizer as specified in torch.optim.
-
-    Returns
-    -------
-        (type):             An uninitialized Pytorch optimizer. Takes as input
-                            the model class' parameters method, the learning
-                            rate, and an optional dictionary of kwargs.
-
+    Attributes
+    ----------
+    name : str
+        The string name of the function or metric.
+    fn : Any
+        The instantiated callable (torchmetrics metric instance or
+        ``torch.nn.functional`` function).
+    requires_argmax : bool
+        Whether predictions and targets must be argmaxed before being
+        passed to ``fn``.
+    requires_flatten : bool
+        Whether predictions and targets must be flattened before being
+        passed to ``fn``.
+    flatten_dims : tuple | None
+        The ``(start_dim, end_dim)`` pair to use when flattening.
+        ``None`` when ``requires_flatten`` is ``False``.
     """
-    return getattr(optim, optimizer)
+
+    name: str
+    fn: Any
+    requires_argmax: bool
+    requires_flatten: bool
+    flatten_dims: tuple | None
 
 
-def get_lr_scheduler(
-    scheduler: str,
-) -> type[tuple[type, float, None | dict[str, Any]]]:
-    """Return user's choice of learning rate scheduler.
-
-    A helper method to retrieve the user's choice of learning rate scheduler.
-
-    Args:
-    ----
-        scheduler (str):    The scheduler as specified in torch.optim.
-
-    Returns
-    -------
-        (type):             An uninitialized Pytorch learning rate scheduler.
-                            Takes as input a Pytorch optimizer object and an
-                            optional dictionary of kwargs.
-
+def get_optim(optimizer: str) -> type[torch.optim.Optimizer]:
     """
-    return getattr(lr_scheduler, scheduler)
+    Return user's choice of optimizer class.
 
-
-def prepare_functions(user_args: str | dict[str, Any], is_loss: bool) -> dict:
-    """Set up and return a user's choice of functions along with configuration requirements.
-
-    Unpacks user_args and fetches the correct functions with any kwargs.
-    This is only performed once during the training run.
-    Loss functions are found in `torch.nn.functional`, otherwise found in `torchmetrics`.
+    A helper method to retrieve the user's choice of optimizer from the
+    torch.optim module.
 
     Parameters
     ----------
-    user_args : str | dict[str, Any]
-        User-specified arguments for the function, either as a string or a dictionary.
+    optimizer : str
+        The name of the optimizer as specified in `torch.optim`
+        (e.g., "Adam", "SGD").
 
     Returns
     -------
-    dict
-        functions (dict): A dictionary where each key is a metric name and each value is a tuple
-                          containing a prepared function suitable for a task in the trainer module
-                          and required configurations for the metric.
-
+    type[torch.optim.Optimizer]
+        The uninitialized PyTorch optimizer class. This class can be
+        instantiated by passing the model parameters and learning rate.
     """
-    functions = {}
-    if isinstance(user_args, dict):
-        for _metric in user_args:
-            kwargs = user_args[_metric]
-            if is_loss:
-                loss_f_cls = getattr(f, _metric)
-                loss_f = loss_f_cls(**kwargs)
-                # loss_f = partial(getattr(f, _metric), **kwargs)
-            else:
-                loss_f_cls = getattr(tm, _metric)
-                loss_f = loss_f_cls(**kwargs)
-                # loss_f = partial(getattr(tm, _metric), **kwargs)
+    return getattr(torch.optim, optimizer)
 
-            loss_f.requires_argmax = requires_argmax(_metric)
-            loss_f.requires_flatten = requires_flatten(_metric)
-            functions[_metric] = loss_f
+
+def get_lr_scheduler(scheduler: str) -> type[torch.optim.lr_scheduler.LRScheduler | torch.optim.lr_scheduler.ReduceLROnPlateau]:
+    """
+    Return user's choice of learning rate scheduler class.
+
+    A helper method to retrieve the uninitialized class of a learning rate
+    scheduler from the `torch.optim.lr_scheduler` module.
+
+    Parameters
+    ----------
+    scheduler : str
+        The name of the scheduler as specified in `torch.optim.lr_scheduler`
+        (e.g., "StepLR", "CosineAnnealingLR").
+
+    Returns
+    -------
+    type[torch.optim.lr_scheduler.LRScheduler] | type[torch.optim.lr_scheduler.ReduceLROnPlateau]
+        The uninitialized learning rate scheduler class. This class typically
+        requires a `torch.optim.Optimizer` instance and specific hyperparameter
+        kwargs for instantiation.
+    """
+    return getattr(torch.optim.lr_scheduler, scheduler)
+
+
+def prepare_functions(user_args: str | dict, is_loss: bool) -> dict[str, PreparedFunction]:
+    """Set up and return a user's choice of performance measuring functions along with configuration requirements.
+
+    Unpacks user_args and fetches the correct functions with any kwargs.
+    If ``is_loss=True`` functions are found in ``torch.nn.functional``,
+    otherwise found in ``torchmetrics``.
+
+    Parameters
+    ----------
+    user_args : str | dict
+        User-specified arguments for the function, either as a string (no
+        kwargs) or a dictionary mapping function names to their kwargs.
+    is_loss : bool
+        Flag indicating whether to prepare a loss function or a performance
+        metric.
+
+    Returns
+    -------
+    dict[str, PreparedFunction]
+        A dictionary where each key is a metric/loss name and each value is
+        a :class:`PreparedFunction` instance carrying the callable and its
+        required configurations.
+    """
+    functions: dict[str, PreparedFunction] = {}
+
+    if isinstance(user_args, dict):
+        for name, kwargs in user_args.items():
+            fn = _build_fn(name, kwargs, is_loss)
+            functions[name] = _wrap(name, fn)
+
+    elif isinstance(user_args, str):
+        fn = _build_fn(user_args, {}, is_loss)
+        functions[user_args] = _wrap(user_args, fn)
 
     else:
-        if is_loss:
-            loss_f = getattr(f, user_args)
-        else:
-            loss_f = getattr(tm, user_args)
-            loss_f = loss_f(**{})
-
-        loss_f.requires_argmax = requires_argmax(user_args)
-        loss_f.requires_flatten = requires_flatten(user_args)
-        functions[user_args] = loss_f
+        logger.error('Function must be defined as a dict or str.')
+        exit(101)
 
     return functions
 
 
-def requires_argmax(metric: str) -> bool:
-    """ Returns a bool indicating whether the defined metric requires
-    that the predictions and targets be argmaxed.
+def _build_fn(name: str, kwargs: dict, is_loss: bool) -> Any:
+    """Instantiate (or retrieve) a loss function or torchmetrics metric.
 
-    See the following link for details on additional metrics that might need to be added
-    to this list in the future:
-    https://lightning.ai/docs/torchmetrics/stable/
-    """
-
-    if metric in ARGMAX_METRICS:
-        return True
-    else:
-        return False
-
-def requires_flatten(metric: str) -> tuple:
-    """ Returns a tuple indicating whether the defined metric requires
-    that the predictions and targets be flattened along with from-to-what dimensions to flatten.
-
-    See the following link for details on additional metrics that might need to be added
-    to this list in the future:
-    https://lightning.ai/docs/torchmetrics/stable/
-    """
-
-    if metric in FLATTEN_METRICS:
-        return True, FLATTEN_METRICS[metric]
-    else:
-        return False, None
-
-def get_model_score(model_dir: str) -> tuple:
-    """
-    This function scans the specified directory for a checkpoint file (indicated by "ckpt" in the filename),
-    loads the checkpoint, and extracts the best score, the corresponding monitored metric, and epoch number,
-    from the callbacks section. If there is no best score, it is assumed that the model at the last epoch was
-    stored and the score is retrieved from the `/lightning_logs/version_0/metrics.csv` file.
+    Loss functions from ``torch.nn.functional`` are plain callables. If kwargs
+    are provided they are bound eagerly via :func:`functools.partial`, since
+    these functions accept their arguments at call time rather than construction
+    time. Torchmetrics classes are instantiated with ``**kwargs``.
 
     Parameters
     ----------
-        model_dir (str): Path to the directory containing the model's checkpoint file.
+    name : str
+        Attribute name on ``torch.nn.functional`` or ``torchmetrics``.
+    kwargs : dict
+        Keyword arguments bound via ``functools.partial`` for loss functions,
+        or forwarded to the torchmetrics constructor for metrics.
+    is_loss : bool
+        When ``True`` the callable is sourced from ``torch.nn.functional``;
+        otherwise it is sourced from ``torchmetrics``.
 
     Returns
     -------
-        tuple: A tuple containing:
-            - best_model_score (float): The best score achieved by the model.
-            - monitor (str): The name of the metric being monitored (e.g., 'val_loss').
-            - epoch (int): The epoch number at which the best score was achieved.
+    Any
+        A ready-to-call loss function (optionally with partial kwargs) or an
+        initialised torchmetrics metric.
+    """
+    if is_loss:
+        fn = getattr(F, name)
+        return functools.partial(fn, **kwargs) if kwargs else fn
+    return getattr(torchmetrics, name)(**kwargs)
 
-    Notes:
-        - Assumes only one checkpoint file exists in the directory.
-        - Requires PyTorch for loading the checkpoint file.
+
+def _wrap(name: str, fn: Any) -> PreparedFunction:
+    """Wrap a callable in a :class:`PreparedFunction` with its config flags.
+
+    Parameters
+    ----------
+    name : str
+        The string identifier of the metric or loss function.
+    fn : Any
+        The callable to wrap.
+
+    Returns
+    -------
+    PreparedFunction
+        The callable bundled with its argmax / flatten requirements.
+    """
+    _requires_flatten, _flatten_dims = requires_flatten(name)
+    return PreparedFunction(
+        name=name,
+        fn=fn,
+        requires_argmax=requires_argmax(name),
+        requires_flatten=_requires_flatten,
+        flatten_dims=_flatten_dims,
+    )
+
+
+def requires_argmax(metric: str) -> bool:
+    """Return whether the metric requires argmaxed predictions and targets.
+
+    The check is first performed with the metric name as-is against
+    :data:`ARGMAX_METRICS`.  If no match is found a second case-insensitive
+    check is performed by lowercasing both the query and every entry in the
+    set.
+
+    See https://lightning.ai/docs/torchmetrics/stable/
+    or https://docs.pytorch.org/docs/stable/nn.functional.html#loss-functions for a full list of
+    available metrics.
+
+    Parameters
+    ----------
+    metric : str
+        The name of the metric.
+
+    Returns
+    -------
+    bool
+        ``True`` if the metric requires argmax, ``False`` otherwise.
+    """
+    if metric in ARGMAX_METRICS:
+        return True
+    return metric.lower() in {m.lower() for m in ARGMAX_METRICS}
+
+
+def requires_flatten(metric: str) -> tuple[bool, tuple | None]:
+    """Return whether the metric requires flattened predictions and targets.
+
+    The check is first performed with the metric name as-is against
+    :data:`FLATTEN_METRICS`.  If no match is found a second case-insensitive
+    check is performed by lowercasing both the query and every key in the
+    dictionary.
+
+    See https://lightning.ai/docs/torchmetrics/stable/
+    or https://docs.pytorch.org/docs/stable/nn.functional.html#loss-functions for a full list of
+    available metrics.
+
+    Parameters
+    ----------
+    metric : str
+        The name of the metric.
+
+    Returns
+    -------
+    tuple[bool, tuple | None]
+        A ``(requires_flatten, flatten_dims)`` pair.  ``flatten_dims`` is the
+        ``(start_dim, end_dim)`` tuple when flattening is required, otherwise
+        ``None``.
+    """
+    if metric in FLATTEN_METRICS:
+        return True, FLATTEN_METRICS[metric]
+
+    lower_map = {k.lower(): v for k, v in FLATTEN_METRICS.items()}
+    if metric.lower() in lower_map:
+        return True, lower_map[metric.lower()]
+
+    return False, None
+
+
+def get_model_score(model_dir: str) -> tuple:
+    """
+    Scan a directory for a checkpoint file, load it, and extract the best score,
+    monitored metric, and corresponding epoch.
+
+    If no best score is found in the checkpoint, the function assumes that the
+    final epoch model was saved and retrieves the score from the
+    ``/lightning_logs/version_0/metrics.csv`` file.
+
+    Parameters
+    ----------
+    model_dir : str
+        Path to the directory containing the model checkpoint file.
+
+    Returns
+    -------
+    best_model_score : float
+        The best score achieved by the model.
+    monitor : str
+        Name of the monitored metric (e.g., ``'val_loss'``).
+    epoch : int
+        Epoch at which the best score was achieved.
+
+    Notes
+    -----
+    - Assumes only one checkpoint file exists in the directory.
+    - Requires PyTorch to load the checkpoint file.
     """
     ckpt_name = [f for f in os.listdir(model_dir) if "ckpt" in f]
     ckpt_name = next(iter(ckpt_name))
@@ -191,7 +304,7 @@ def get_model_score(model_dir: str) -> tuple:
         best_score = best_score.item()
     else:
         lc_info = os.path.join(model_dir, "lightning_logs", "version_0", "metrics.csv")
-        metrics_df = pd.read_csv(lc_info)
+        metrics_df = read_csv(lc_info)
         valid_loss_df = metrics_df[metric]
         best_score = valid_loss_df.loc[valid_loss_df.last_valid_index()]
 

--- a/trainer/model_config.py
+++ b/trainer/model_config.py
@@ -18,19 +18,20 @@ __licence__ = 'Apache 2.0; see LICENSE file for details.'
 __author__ = "randlerabe@gmail.com, tiantheunissen@gmail.com, moutoncoenraad@gmail.com"
 __description__ = "Constructs a Pytorch Lightning model class."
 
-from typing import TYPE_CHECKING, Any, Callable
+# standard library imports
+import copy
+from typing import TYPE_CHECKING, Any
 
+# external imports
 from pytorch_lightning import LightningModule
 from torch import argmax
 from torch import nn
-import torchmetrics as tm
 
+# internal imports
 from helpers.fetch_torch_mods import (
     get_lr_scheduler,
     get_optim,
     prepare_functions,
-    requires_argmax,
-    requires_flatten
 )
 from helpers.logger import get_logger
 
@@ -39,6 +40,7 @@ if TYPE_CHECKING:
     from torch.nn import Module
 
 logger = get_logger()
+
 
 class PLModel(LightningModule):
 
@@ -53,6 +55,37 @@ class PLModel(LightningModule):
         model_params: dict[str, Any],
         output_scaler: None | object = None
     ) -> None:
+        """Initialize the PLModel.
+
+        Parameters
+        ----------
+        loss : str | dict[str, Any]
+            Loss function name or a dictionary mapping a loss function name to
+            its kwargs, as specified in ``torch.nn.functional``.
+        learning_rate : float
+            Learning rate passed to the optimizer.
+        optimizer : str | dict[str, Any]
+            Optimizer name or a dictionary mapping an optimizer name to its
+            kwargs, as specified in ``torch.optim``.
+        learning_rate_scheduler : None | str | dict[str, Any]
+            Learning rate scheduler name or a dictionary mapping a scheduler
+            name to its kwargs, as specified in
+            ``torch.optim.lr_scheduler``. Pass ``None`` to disable.
+        performance_metrics : None | str | dict[str, Any]
+            Performance metric name or a dictionary mapping metric names to
+            their kwargs, as specified in ``torchmetrics``. Pass ``None`` to
+            disable performance metric tracking.
+        model : Module
+            Uninitialised PyTorch model class.
+        model_params : dict[str, Any]
+            Keyword arguments forwarded to ``model`` at construction time.
+        output_scaler : None | object, optional
+            A fitted scaler with an ``inverse_transform`` method.
+            When provided, predictions and targets are
+            inverse-transformed before loss and metric computation.
+            Default is ``None``.
+        """
+
         super().__init__()
 
         self.lr = learning_rate
@@ -65,13 +98,7 @@ class PLModel(LightningModule):
         self.loss_functions = prepare_functions(user_args=loss, is_loss=True)
 
         if self.performance_metrics is not None:
-            self.metrics = nn.ModuleDict({
-                "trn": self._build_metric_collection(),
-                "val": self._build_metric_collection(),
-                "result_train": self._build_metric_collection(),
-                "result_valid": self._build_metric_collection(),
-                "result_eval": self._build_metric_collection(),
-            })
+            self._metric_configs, self.metrics = self._make_metrics()
 
         self.save_hyperparameters(ignore=['model'])
 
@@ -79,31 +106,63 @@ class PLModel(LightningModule):
     # Initial construction methods
     # ----------------------------
 
-    def _build_metric_collection(self) -> nn.ModuleDict:
-        """Build a ModuleDict of individual metrics, each stored with its config."""
+    def _make_metrics(self) -> tuple[dict, nn.ModuleDict]:
+        """Build metric configs and per-split metric module dicts.
 
-        metrics = prepare_functions(self.performance_metrics, is_loss=False)
-        return nn.ModuleDict(metrics)
+        Calls ``prepare_functions`` once to obtain :class:`PreparedFunction`
+        instances, stores their configs for later use during stepping, and
+        creates independent deep-copied metric instances for each data split
+        to ensure per-split state isolation.
+
+        Returns
+        -------
+        tuple[dict, nn.ModuleDict]
+            A tuple of:
+
+            - **configs** (*dict*): Maps metric names to their
+              :class:`PreparedFunction` instances, used to look up
+              ``requires_argmax`` and ``requires_flatten`` during stepping.
+            - **metrics** (*nn.ModuleDict*): A nested ``ModuleDict`` keyed
+              first by split name and then by metric name, each holding an
+              independent torchmetrics metric instance.
+        """
+
+        prepared = prepare_functions(self.performance_metrics, is_loss=False)
+        configs = {name: pf for name, pf in prepared.items()}
+        metrics = nn.ModuleDict({
+            split: nn.ModuleDict({name: copy.deepcopy(pf.fn) for name, pf in prepared.items()})
+            for split in ("trn", "val", "result_train", "result_valid", "result_eval")
+        })
+        return configs, metrics
 
     def configure_optimizers(self) -> dict[str, Any]:
         """Return configured optimizer and optional learning rate scheduler.
 
-        Overrides the method in pl.LightningModule.
+        Overrides :meth:`pytorch_lightning.LightningModule.configure_optimizers`.
+
+        Returns
+        -------
+        dict[str, Any]
+            A dictionary with an ``"optimizer"`` key and, if a learning rate
+            scheduler is configured, an ``"lr_scheduler"`` key.
         """
-        if self.optimizer:
-            if isinstance(self.optimizer, dict):
-                for optim in self.optimizer:
-                    opt_kwargs = self.optimizer[optim]
-                    optimizer = get_optim(optim)(
-                        params=self.model.parameters(),
-                        lr=self.lr,
-                        **opt_kwargs,
-                    )
-            else:
-                optimizer = get_optim(self.optimizer)(
+
+        if not self.optimizer:
+            logger.error("No optimizer specified. Cannot configure optimizers.")
+            exit(101)
+
+        if isinstance(self.optimizer, dict):
+            for optim_name, opt_kwargs in self.optimizer.items():
+                optimizer = get_optim(optim_name)(
                     params=self.model.parameters(),
                     lr=self.lr,
+                    **opt_kwargs,
                 )
+        else:
+            optimizer = get_optim(self.optimizer)(
+                params=self.model.parameters(),
+                lr=self.lr,
+            )
 
         if self.lr_scheduler:
             if isinstance(self.lr_scheduler, dict):
@@ -127,7 +186,22 @@ class PLModel(LightningModule):
     # Main stepping functions
     # -----------------------
 
-    def training_step(self, batch: dict[str, Any], batch_idx: int):
+    def training_step(self, batch: dict[str, Any], batch_idx: int) -> Tensor:
+        """Perform a single training step.
+
+        Parameters
+        ----------
+        batch : dict[str, Any]
+            A dictionary containing at least ``"x"`` (model inputs) and
+            ``"y"`` (targets).
+        batch_idx : int
+            Index of the current batch.
+
+        Returns
+        -------
+        Tensor
+            The combined training loss for the current batch.
+        """
         y_pred = self.model.forward(batch['x'])
 
         loss, loss_log_metrics = self._compute_loss(
@@ -135,13 +209,28 @@ class PLModel(LightningModule):
         )
 
         if self.performance_metrics is not None:
-            self._update_performance(batch['y'], y_pred, split="trn", perf_label="train_perf_")
+            self._update_performance(batch['y'], y_pred, split="trn")
 
         loss_log_metrics['epoch'] = float(self.current_epoch)
         self.log_dict(loss_log_metrics, on_epoch=True, on_step=False, prog_bar=True)
         return loss
 
-    def validation_step(self, batch: dict[str, Any], batch_idx: int):
+    def validation_step(self, batch: dict[str, Any], batch_idx: int) -> Tensor:
+        """Perform a single validation step.
+
+        Parameters
+        ----------
+        batch : dict[str, Any]
+            A dictionary containing at least ``"x"`` (model inputs) and
+            ``"y"`` (targets).
+        batch_idx : int
+            Index of the current batch.
+
+        Returns
+        -------
+        Tensor
+            The combined validation loss for the current batch.
+        """
         y_pred = self.model.forward(batch['x'])
 
         loss, loss_log_metrics = self._compute_loss(
@@ -149,17 +238,35 @@ class PLModel(LightningModule):
         )
 
         if self.performance_metrics is not None:
-            self._update_performance(batch['y'], y_pred, split="val", perf_label="valid_perf_")
+            self._update_performance(batch['y'], y_pred, split="val")
 
         loss_log_metrics['epoch'] = float(self.current_epoch)
         self.log_dict(loss_log_metrics, on_epoch=True, on_step=False, prog_bar=True)
         return loss
 
-    def test_step(self, batch: dict[str, Any], batch_idx: int, dataloader_idx: int):
+    def test_step(self, batch: dict[str, Any], batch_idx: int, dataloader_idx: int) -> dict[str, Tensor]:
+        """Perform a single test step.
+
+        Parameters
+        ----------
+        batch : dict[str, Any]
+            A dictionary containing at least ``"x"`` (model inputs) and
+            ``"y"`` (targets).
+        batch_idx : int
+            Index of the current batch.
+        dataloader_idx : int
+            Index of the current dataloader. ``0`` corresponds to the training
+            set, ``1`` to the validation set, and ``2`` to the evaluation set.
+
+        Returns
+        -------
+        dict[str, Tensor]
+            A dictionary of logged loss metrics for the current batch.
+        """
         loaders = {0: "result_train_", 1: "result_valid_", 2: "result_eval_"}
-        splits  = {0: "result_train",  1: "result_valid",  2: "result_eval"}
+        splits = {0: "result_train", 1: "result_valid", 2: "result_eval"}
         current_loader = loaders[dataloader_idx]
-        current_split  = splits[dataloader_idx]
+        current_split = splits[dataloader_idx]
 
         y_pred = self.model.forward(batch['x'])
 
@@ -168,9 +275,7 @@ class PLModel(LightningModule):
         )
 
         if self.performance_metrics is not None:
-            self._update_performance(
-                batch['y'], y_pred, split=current_split, perf_label=current_loader + "perf_"
-            )
+            self._update_performance(batch['y'], y_pred, split=current_split)
 
         self.log_dict(
             loss_log_metrics,
@@ -185,32 +290,61 @@ class PLModel(LightningModule):
 
     def _compute_loss(self, y: float | Tensor, y_pred: float | Tensor, loss_label: str) -> tuple[float | Tensor, dict[str, float | Tensor]]:
 
+        """Compute the loss over all configured loss functions for a single batch.
+
+        Applies any required argmax or flatten transformations to the predictions
+        and targets before computing each loss. If an ``output_scaler`` is set,
+        the loss is also computed on inverse-transformed outputs and overwrites
+        the original loss in the log. The final combined loss is produced by
+        :meth:`_loss_combiner`.
+
+        Parameters
+        ----------
+        y : Tensor
+            Ground-truth targets for the current batch.
+        y_pred : Tensor
+            Model predictions for the current batch.
+        loss_label : str
+            Prefix used when constructing log metric keys
+            (e.g., ``"train_loss"``).
+
+        Returns
+        -------
+        tuple[Tensor, dict[str, Tensor]]
+            A tuple of:
+
+            - **loss** (*Tensor*): The combined scalar loss used for
+              backpropagation.
+            - **log_metrics** (*dict[str, Tensor]*): A dictionary mapping
+              ``"{loss_label}_{function_name}"`` to the corresponding loss
+              value for logging.
+        """
+
         log_metrics: dict[str, float | Tensor] = {}
         losses = []
 
-        for _function in self.loss_functions:
+        for name, prepared in self.loss_functions.items():
 
             targets = y.clone()
             predictions = y_pred.clone()
-            function = self.loss_functions[_function]
 
-            if function.requires_argmax:
+            if prepared.requires_argmax:
                 targets = argmax(targets, dim=1).to(self.device)
                 predictions = argmax(predictions, dim=1).to(self.device)
-            if function.requires_flatten[0]:
-                targets = targets.flatten(start_dim=function.requires_flatten[1][0], end_dim=function.requires_flatten[1][1]).to(self.device)
-                predictions = predictions.flatten(start_dim=function.requires_flatten[1][0], end_dim=function.requires_flatten[1][1]).to(self.device)
+            if prepared.requires_flatten:
+                targets = targets.flatten(start_dim=prepared.flatten_dims[0], end_dim=prepared.flatten_dims[1]).to(self.device)
+                predictions = predictions.flatten(start_dim=prepared.flatten_dims[0], end_dim=prepared.flatten_dims[1]).to(self.device)
 
-            loss = function(input=predictions, target=targets)
+            loss = prepared.fn(input=predictions, target=targets)
             losses.append(loss)
-            log_metrics[loss_label + '_' + _function] = loss
+            log_metrics[loss_label + '_' + name] = loss
 
             if self.output_scaler is not None:
                 predictions = self.output_scaler.inverse_transform(predictions.clone().detach().cpu()).to(self.device)
-                if not function.requires_argmax:
+                if not prepared.requires_argmax:
                     targets = self.output_scaler.inverse_transform(targets.clone().detach().cpu()).to(self.device)
-                loss_rescaled = function(input=predictions, target=targets)
-                log_metrics[loss_label + '_' + _function] = loss_rescaled
+                loss_rescaled = prepared.fn(input=predictions, target=targets)
+                log_metrics[loss_label + '_' + name] = loss_rescaled
 
         loss = self._loss_combiner(losses)
 
@@ -223,11 +357,44 @@ class PLModel(LightningModule):
 
         return loss, log_metrics
 
-    def _loss_combiner(self, losses):
+    def _loss_combiner(self, losses: list[Tensor]) -> Tensor:
+        """Combine multiple loss values into a single scalar loss.
 
+        Currently returns the first loss only. This is a placeholder intended
+        to be extended to support weighted combinations of multiple losses in
+        a future iteration.
+
+        Parameters
+        ----------
+        losses : list[Tensor]
+            A list of scalar loss tensors, one per configured loss function.
+
+        Returns
+        -------
+        Tensor
+            The combined scalar loss.
+        """
         return losses[0]
 
-    def _update_performance(self, y: Tensor, y_pred: Tensor, split: str, perf_label: str) -> None:
+    def _update_performance(self, y: Tensor, y_pred: Tensor, split: str) -> None:
+        """Accumulate per-batch predictions and targets into metric states.
+
+        Applies inverse scaling if an ``output_scaler`` is set, then applies
+        any required argmax or flatten transformations before calling
+        ``metric.update()`` on each configured metric for the given split.
+        Metrics accumulate state across batches; call
+        :meth:`_compute_and_log_performance` at epoch end to finalize and log.
+
+        Parameters
+        ----------
+        y : Tensor
+            Ground-truth targets for the current batch.
+        y_pred : Tensor
+            Model predictions for the current batch.
+        split : str
+            The data split key (e.g., ``"trn"``, ``"val"``, ``"result_eval"``).
+        """
+
         targets = y.detach()
         predictions = y_pred.detach()
 
@@ -240,19 +407,36 @@ class PLModel(LightningModule):
             ).to(self.device)
 
         for metric_name, metric in self.metrics[split].items():
+            config = self._metric_configs[metric_name]
             t = targets.clone()
             p = predictions.clone()
 
-            if metric.requires_argmax:
+            if config.requires_argmax:
                 t = argmax(t, dim=1).to(self.device)
                 p = argmax(p, dim=1).to(self.device)
-            if metric.requires_flatten[0]:
-                t = t.flatten(start_dim=metric.requires_flatten[1][0], end_dim=metric.requires_flatten[1][1]).to(self.device)
-                p = p.flatten(start_dim=metric.requires_flatten[1][0], end_dim=metric.requires_flatten[1][1]).to(self.device)
+            if config.requires_flatten:
+                t = t.flatten(start_dim=config.flatten_dims[0], end_dim=config.flatten_dims[1]).to(self.device)
+                p = p.flatten(start_dim=config.flatten_dims[0], end_dim=config.flatten_dims[1]).to(self.device)
 
             metric.update(p, t)
 
     def _compute_and_log_performance(self, split: str, perf_label: str) -> None:
+        """Compute epoch-level metrics from accumulated state and log them.
+
+        Calls ``metric.compute()`` on each metric for the given split to
+        obtain the epoch-level aggregated value, logs all metrics via
+        :meth:`log_dict`, then resets each metric's internal state ready
+        for the next epoch.
+
+        Parameters
+        ----------
+        split : str
+            The data split key (e.g., ``"trn"``, ``"val"``, ``"result_eval"``).
+        perf_label : str
+            Prefix used when constructing log metric keys
+            (e.g., ``"train_perf_"``).
+        """
+
         log_metrics = {}
         for metric_name, metric in self.metrics[split].items():
             log_metrics[perf_label + metric_name] = metric.compute()
@@ -263,32 +447,35 @@ class PLModel(LightningModule):
     # Callbacks
     # ---------
 
-    def on_train_epoch_end(self):
-        """ Set the next training epoch number in the CustomSampler.
+    def on_train_epoch_end(self) -> None:
+        """Compute and log training metrics, then advance the sampler epoch.
 
-        This is done to manage potential stochasticity (which is connected to the epoch number).
-
+        Finalizes accumulated metric state for the ``"trn"`` split and logs
+        epoch-level results. Also advances the epoch counter in the
+        ``CustomSampler`` if present, to manage any epoch-linked stochasticity.
         """
         if self.performance_metrics is not None:
             self._compute_and_log_performance("trn", "train_perf_")
         if hasattr(self.trainer.train_dataloader.batch_sampler, 'set_epoch'):
             self.trainer.train_dataloader.batch_sampler.set_epoch(self.current_epoch+1)
 
-    def on_validation_epoch_end(self):
+    def on_validation_epoch_end(self) -> None:
+        """Compute and log validation metrics at the end of each epoch."""
         if self.performance_metrics is not None:
             self._compute_and_log_performance("val", "valid_perf_")
 
-    def on_train_epoch_start(self):
+    def on_train_epoch_start(self) -> None:
         """ Reset the model internal states for new training epoch."""
         if hasattr(self.model, 'force_reset'):
             self.model.force_reset()
 
-    def on_validation_epoch_start(self):
+    def on_validation_epoch_start(self) -> None:
         """ Reset the model internal states for new validation epoch."""
         if hasattr(self.model, 'force_reset'):
             self.model.force_reset()
 
-    def on_test_epoch_end(self):
+    def on_test_epoch_end(self) -> None:
+        """Compute and log test metrics for all result splits at epoch end."""
         if self.performance_metrics is not None:
             for split, label in [
                 ("result_train", "result_train_perf_"),
@@ -297,14 +484,28 @@ class PLModel(LightningModule):
             ]:
                 self._compute_and_log_performance(split, label)
 
-    def on_test_epoch_start(self):
+    def on_test_epoch_start(self) -> None:
         """ Reset the model internal states for new validation epoch."""
         if hasattr(self.model, 'force_reset'):
             self.model.force_reset()
 
-    def on_test_batch_start(self, batch, batch_idx, dataloader_idx=0):
-        """ Update model internal states if applicable. Also hard sets the internal states to the
-        final prediction point in the batch in case of variable length inputs."""
+    def on_test_batch_start(self, batch, batch_idx, dataloader_idx=0) -> None:
+        """Update and optionally reset model internal states at the start of each test batch.
+
+        Resets internal states on the first batch of each dataloader. Updates
+        recurrent or stateful model internals and hard-sets states to the final
+        prediction point in the batch if applicable.
+
+        Parameters
+        ----------
+        batch : dict[str, Any]
+            The current batch dictionary.
+        batch_idx : int
+            Index of the current batch.
+        dataloader_idx : int, optional
+            Index of the current dataloader. Default is ``0``.
+        """
+
         if batch_idx == 0:
             if hasattr(self.model, 'force_reset'):
                 self.model.force_reset()
@@ -313,7 +514,7 @@ class PLModel(LightningModule):
         if hasattr(self.model, 'hard_set_states'):
             self.model.hard_set_states(batch['ist_idx'][-1])
 
-    def on_train_batch_start(self, batch, batch_idx, dataloader_idx=0):
+    def on_train_batch_start(self, batch, batch_idx, dataloader_idx=0) -> None:
         """ Update model internal states if applicable. Also hard sets the internal states to the
         final prediction point in the batch in case of variable length inputs."""
         if hasattr(self.model, 'update_states'):
@@ -321,7 +522,7 @@ class PLModel(LightningModule):
         if hasattr(self.model, 'hard_set_states'):
             self.model.hard_set_states(batch['ist_idx'][-1])
 
-    def on_validation_batch_start(self, batch, batch_idx, dataloader_idx=0):
+    def on_validation_batch_start(self, batch, batch_idx, dataloader_idx=0) -> None:
         """ Update model internal states if applicable. Also hard sets the internal states to the
         final prediction point in the batch in case of variable length inputs."""
         if hasattr(self.model, 'update_states'):
@@ -329,7 +530,7 @@ class PLModel(LightningModule):
         if hasattr(self.model, 'hard_set_states'):
             self.model.hard_set_states(batch['ist_idx'][-1])
 
-    def on_predict_batch_start(self, batch, batch_idx, dataloader_idx=0):
+    def on_predict_batch_start(self, batch, batch_idx, dataloader_idx=0) -> None:
         """ Update model internal states if applicable. Also hard sets the internal states to the
         final prediction point in the batch in case of variable length inputs."""
         if hasattr(self.model, 'update_states'):

--- a/trainer/model_config.py
+++ b/trainer/model_config.py
@@ -15,18 +15,22 @@ https://lightning.ai/docs/pytorch/stable/common/lightning_module.html
 from __future__ import annotations
 __copyright__ = 'Copyright (c) 2025 North-West University (NWU), South Africa.'
 __licence__ = 'Apache 2.0; see LICENSE file for details.'
-__author__ = "randlerabe@gmail.com, tiantheunissen@gmail.com"
+__author__ = "randlerabe@gmail.com, tiantheunissen@gmail.com, moutoncoenraad@gmail.com"
 __description__ = "Constructs a Pytorch Lightning model class."
 
 from typing import TYPE_CHECKING, Any, Callable
 
-import pytorch_lightning as pl
+from pytorch_lightning import LightningModule
 from torch import argmax
+from torch import nn
+import torchmetrics as tm
 
 from helpers.fetch_torch_mods import (
     get_lr_scheduler,
     get_optim,
-    prepare_function,
+    prepare_functions,
+    requires_argmax,
+    requires_flatten
 )
 from helpers.logger import get_logger
 
@@ -36,100 +40,7 @@ if TYPE_CHECKING:
 
 logger = get_logger()
 
-class PLModel(pl.LightningModule):
-    """Wrapper class to prepare model for Pytorch Lightning's Trainer.
-
-    The class initializes a Pytorch model and defines the training,
-    validation, and test steps over a batch. The optimizer configuration is
-    also set inside this class. This is required for Pytorch Lightning's
-    Trainer.
-
-    Parameters
-    ----------
-    loss : str, dict[str, Any]
-        The loss function to be used during training. The string must match the
-        name in Pytorch's functional library. See:
-        https://pytorch.org/docs/stable/nn.functional.html#loss-functions
-
-    learning_rate : float
-        The learning rate to be used during training.
-
-    optimizer : str | dict[str, Any]
-        The optimizer to be used during training. The string must match the
-        name in Pytorch's optimizer library. See:
-        https://pytorch.org/docs/stable/nn.functional.html#loss-functions
-
-    learning_rate_scheduler : None | str | dict[str, Any], default=None
-        The learning rate scheduler to be used during training. If not None, a
-        dictionary must be given of the form
-
-            ``{scheduler: scheduler_kwargs}``
-
-        where
-            scheduler:  A string that specifies the Pytorch scheduler to be
-            used. Must match names found here:
-            https://pytorch.org/docs/stable/optim.html#module-torch.optim.lr_scheduler
-
-            scheduler_kwargs: A dictionary of kwargs required for 'scheduler'.
-
-    performance_metrics : None | str | dict[str, Any], default=None
-        Performance metrics to be logged during training. If type=dict, then
-        the dictionary must be given of the form
-
-            ``{metric: metric_kwargs}``
-
-        where
-            metric: A string that specifies the TORCHMETRICS metric to be
-            used. Must match the functional interface names found here:
-            https://lightning.ai/docs/torchmetrics/stable/
-
-            metric_kwargs: A dictionary of kwargs required for 'metric'.
-
-    model : Module
-        An unitialized Pytorch model class defined in the user's model direc-
-        tory.
-
-    model_params : dict[str, Any]
-        The parameters needed to instantiate the above Pytorch model class.
-
-    output_scaler : None | object, default=None
-        The scaling object to rescale the model outputs to original ranges (if applicable)
-        during performance calculations. Must have an appropriate `inverse_transform` function.
-        If None, no rescaling is performed. Note, only applicable to logged metrics,
-        gradients are still calculated with scaled outputs (if applicable).
-
-
-    Attributes
-    ----------
-    loss : str, dict[str, Any]
-        Stores the name of the loss function to be used during training and any
-        additional kwargs if needed.
-
-    lr : float
-        Stores the value of the learning rate to be used during training.
-
-    lr_scheduler : None | str | dict[str, Any]
-        Stores the name of the learning rate scheduler to be used during
-        training and any additional kwargs if needed.
-
-    optimizer : str | dict[str, Any]
-        Stores the name of the optimizer to be used during training and any
-        additional kwargs if needed.
-
-    performance_metrics : None | str | dict[str, Any], default=None
-        Stores the name of the performance metric(s) to be used during training
-        and any additional kwargs if needed.
-
-    output_scaler : None | object, default=None
-        The scaling object to rescale the model outputs to original ranges (if applicable)
-        during performance calculations. Must have an appropriate `inverse_transform` function.
-        If None, no rescaling is performed. Note, only applicable to logged metrics,
-        gradients are still calculated with scaled outputs (if applicable).
-
-    model : Module
-        An initialized Pytorch model.
-
-    """
+class PLModel(LightningModule):
 
     def __init__(
         self,
@@ -144,16 +55,213 @@ class PLModel(pl.LightningModule):
     ) -> None:
         super().__init__()
 
-        self.loss = loss
         self.lr = learning_rate
         self.lr_scheduler = learning_rate_scheduler
         self.optimizer = optimizer
         self.performance_metrics = performance_metrics
         self.output_scaler = output_scaler
 
-        self.model = self._build_model(model, model_params)
+        self.model = model(**model_params)
+        self.loss_functions = prepare_functions(user_args=loss, is_loss=True)
+
+        if self.performance_metrics is not None:
+            self.metrics = nn.ModuleDict({
+                "trn": self._build_metric_collection(),
+                "val": self._build_metric_collection(),
+                "result_train": self._build_metric_collection(),
+                "result_valid": self._build_metric_collection(),
+                "result_eval": self._build_metric_collection(),
+            })
 
         self.save_hyperparameters(ignore=['model'])
+
+    # ----------------------------
+    # Initial construction methods
+    # ----------------------------
+
+    def _build_metric_collection(self) -> nn.ModuleDict:
+        """Build a ModuleDict of individual metrics, each stored with its config."""
+
+        metrics = prepare_functions(self.performance_metrics, is_loss=False)
+        return nn.ModuleDict(metrics)
+
+    def configure_optimizers(self) -> dict[str, Any]:
+        """Return configured optimizer and optional learning rate scheduler.
+
+        Overrides the method in pl.LightningModule.
+        """
+        if self.optimizer:
+            if isinstance(self.optimizer, dict):
+                for optim in self.optimizer:
+                    opt_kwargs = self.optimizer[optim]
+                    optimizer = get_optim(optim)(
+                        params=self.model.parameters(),
+                        lr=self.lr,
+                        **opt_kwargs,
+                    )
+            else:
+                optimizer = get_optim(self.optimizer)(
+                    params=self.model.parameters(),
+                    lr=self.lr,
+                )
+
+        if self.lr_scheduler:
+            if isinstance(self.lr_scheduler, dict):
+                lr_dict = {}
+                for sched in self.lr_scheduler:
+                    sched_kwargs = self.lr_scheduler[sched]
+                    if "monitor" in sched_kwargs:
+                        monitor = sched_kwargs.pop("monitor")
+                        lr_dict["monitor"] = monitor
+                    scheduler = get_lr_scheduler(sched)(
+                        optimizer=optimizer,
+                        **sched_kwargs,
+                    )
+                    lr_dict["scheduler"] = scheduler
+                return {"optimizer": optimizer, "lr_scheduler": lr_dict}
+            scheduler = get_lr_scheduler(self.lr_scheduler)(optimizer=optimizer)
+            return {"optimizer": optimizer, "lr_scheduler": scheduler}
+        return {"optimizer": optimizer}
+
+    # -----------------------
+    # Main stepping functions
+    # -----------------------
+
+    def training_step(self, batch: dict[str, Any], batch_idx: int):
+        y_pred = self.model.forward(batch['x'])
+
+        loss, loss_log_metrics = self._compute_loss(
+            y=batch['y'], y_pred=y_pred, loss_label="train_loss"
+        )
+
+        if self.performance_metrics is not None:
+            self._update_performance(batch['y'], y_pred, split="trn", perf_label="train_perf_")
+
+        loss_log_metrics['epoch'] = float(self.current_epoch)
+        self.log_dict(loss_log_metrics, on_epoch=True, on_step=False, prog_bar=True)
+        return loss
+
+    def validation_step(self, batch: dict[str, Any], batch_idx: int):
+        y_pred = self.model.forward(batch['x'])
+
+        loss, loss_log_metrics = self._compute_loss(
+            y=batch['y'], y_pred=y_pred, loss_label="valid_loss"
+        )
+
+        if self.performance_metrics is not None:
+            self._update_performance(batch['y'], y_pred, split="val", perf_label="valid_perf_")
+
+        loss_log_metrics['epoch'] = float(self.current_epoch)
+        self.log_dict(loss_log_metrics, on_epoch=True, on_step=False, prog_bar=True)
+        return loss
+
+    def test_step(self, batch: dict[str, Any], batch_idx: int, dataloader_idx: int):
+        loaders = {0: "result_train_", 1: "result_valid_", 2: "result_eval_"}
+        splits  = {0: "result_train",  1: "result_valid",  2: "result_eval"}
+        current_loader = loaders[dataloader_idx]
+        current_split  = splits[dataloader_idx]
+
+        y_pred = self.model.forward(batch['x'])
+
+        _, loss_log_metrics = self._compute_loss(
+            y=batch['y'], y_pred=y_pred, loss_label=current_loader + "loss"
+        )
+
+        if self.performance_metrics is not None:
+            self._update_performance(
+                batch['y'], y_pred, split=current_split, perf_label=current_loader + "perf_"
+            )
+
+        self.log_dict(
+            loss_log_metrics,
+            on_epoch=True, on_step=False, prog_bar=True,
+            logger=True, add_dataloader_idx=False,
+        )
+        return loss_log_metrics
+
+    # -------------------------------
+    # Performance measuring functions
+    # -------------------------------
+
+    def _compute_loss(self, y: float | Tensor, y_pred: float | Tensor, loss_label: str) -> tuple[float | Tensor, dict[str, float | Tensor]]:
+
+        log_metrics: dict[str, float | Tensor] = {}
+        losses = []
+
+        for _function in self.loss_functions:
+
+            targets = y.clone()
+            predictions = y_pred.clone()
+            function = self.loss_functions[_function]
+
+            if function.requires_argmax:
+                targets = argmax(targets, dim=1).to(self.device)
+                predictions = argmax(predictions, dim=1).to(self.device)
+            if function.requires_flatten[0]:
+                targets = targets.flatten(start_dim=function.requires_flatten[1][0], end_dim=function.requires_flatten[1][1]).to(self.device)
+                predictions = predictions.flatten(start_dim=function.requires_flatten[1][0], end_dim=function.requires_flatten[1][1]).to(self.device)
+
+            loss = function(input=predictions, target=targets)
+            losses.append(loss)
+            log_metrics[loss_label + '_' + _function] = loss
+
+            if self.output_scaler is not None:
+                predictions = self.output_scaler.inverse_transform(predictions.clone().detach().cpu()).to(self.device)
+                if not function.requires_argmax:
+                    targets = self.output_scaler.inverse_transform(targets.clone().detach().cpu()).to(self.device)
+                loss_rescaled = function(input=predictions, target=targets)
+                log_metrics[loss_label + '_' + _function] = loss_rescaled
+
+        loss = self._loss_combiner(losses)
+
+        if loss is None:
+            logger.error(
+                "Something went wrong when trying to compute the loss.",
+            )
+            e_msg = "The variable 'loss' cannot be None."
+            raise TypeError(e_msg)
+
+        return loss, log_metrics
+
+    def _loss_combiner(self, losses):
+
+        return losses[0]
+
+    def _update_performance(self, y: Tensor, y_pred: Tensor, split: str, perf_label: str) -> None:
+        targets = y.detach()
+        predictions = y_pred.detach()
+
+        if self.output_scaler is not None:
+            predictions = self.output_scaler.inverse_transform(
+                predictions.clone().cpu()
+            ).to(self.device)
+            targets = self.output_scaler.inverse_transform(
+                targets.clone().cpu()
+            ).to(self.device)
+
+        for metric_name, metric in self.metrics[split].items():
+            t = targets.clone()
+            p = predictions.clone()
+
+            if metric.requires_argmax:
+                t = argmax(t, dim=1).to(self.device)
+                p = argmax(p, dim=1).to(self.device)
+            if metric.requires_flatten[0]:
+                t = t.flatten(start_dim=metric.requires_flatten[1][0], end_dim=metric.requires_flatten[1][1]).to(self.device)
+                p = p.flatten(start_dim=metric.requires_flatten[1][0], end_dim=metric.requires_flatten[1][1]).to(self.device)
+
+            metric.update(p, t)
+
+    def _compute_and_log_performance(self, split: str, perf_label: str) -> None:
+        log_metrics = {}
+        for metric_name, metric in self.metrics[split].items():
+            log_metrics[perf_label + metric_name] = metric.compute()
+            metric.reset()
+        self.log_dict(log_metrics, prog_bar=True)
+
+    # ---------
+    # Callbacks
+    # ---------
 
     def on_train_epoch_end(self):
         """ Set the next training epoch number in the CustomSampler.
@@ -161,8 +269,14 @@ class PLModel(pl.LightningModule):
         This is done to manage potential stochasticity (which is connected to the epoch number).
 
         """
+        if self.performance_metrics is not None:
+            self._compute_and_log_performance("trn", "train_perf_")
         if hasattr(self.trainer.train_dataloader.batch_sampler, 'set_epoch'):
             self.trainer.train_dataloader.batch_sampler.set_epoch(self.current_epoch+1)
+
+    def on_validation_epoch_end(self):
+        if self.performance_metrics is not None:
+            self._compute_and_log_performance("val", "valid_perf_")
 
     def on_train_epoch_start(self):
         """ Reset the model internal states for new training epoch."""
@@ -173,6 +287,15 @@ class PLModel(pl.LightningModule):
         """ Reset the model internal states for new validation epoch."""
         if hasattr(self.model, 'force_reset'):
             self.model.force_reset()
+
+    def on_test_epoch_end(self):
+        if self.performance_metrics is not None:
+            for split, label in [
+                ("result_train", "result_train_perf_"),
+                ("result_valid", "result_valid_perf_"),
+                ("result_eval", "result_eval_perf_"),
+            ]:
+                self._compute_and_log_performance(split, label)
 
     def on_test_epoch_start(self):
         """ Reset the model internal states for new validation epoch."""
@@ -213,320 +336,6 @@ class PLModel(pl.LightningModule):
             self.model.update_states(batch['ist_idx'][0], batch['x'].device)
         if hasattr(self.model, 'hard_set_states'):
             self.model.hard_set_states(batch['ist_idx'][-1])
-
-    def training_step(self, batch: dict[str, Any], batch_idx: int):  # type: ignore[return-value]  # noqa: ANN201, ARG002
-        """Compute loss and optional metrics, log metrics, and return the loss.
-
-        Overrides the method in pl.LightningModule.
-        """
-        forward = getattr(self.model, "forward")  # noqa: B009
-        y_pred = forward(batch['x'])
-
-        # compute loss; depends on whether user gave kwargs
-        loss, loss_log_metrics = self._compute_loss(
-            y=batch['y'],
-            y_pred=y_pred,
-            loss_label="train_loss",
-        )
-
-        # compute performance; depends on whether user gave kwargs
-        if self.performance_metrics is None:
-            perf_log_metrics = {}
-        else:
-            perf_log_metrics = self._compute_performance(
-                y=batch['y'],
-                y_pred=y_pred,
-                perf_label="train_perf_",
-            )
-
-        log_metrics = {
-            **loss_log_metrics,
-            **perf_log_metrics,
-        }
-        log_metrics['epoch'] = float(self.current_epoch)
-
-        # The loss and performance is accumulated over an epoch and then
-        # averaged.
-        self.log_dict(  # type: ignore[type]
-            dictionary=log_metrics,
-            on_epoch=True,
-            on_step=False,
-            prog_bar=True,
-        )
-
-        return loss
-
-    def validation_step(self, batch: dict[str, Any], batch_idx: int):  # type: ignore[return-value]  # noqa: ANN201, ARG002
-        """Compute loss and optional metrics, log metrics, and return the loss.
-
-        Overrides the method in pl.LightningModule.
-        """
-
-        forward = getattr(self.model, "forward")  # noqa: B009
-        y_pred = forward(batch['x'])
-
-        # compute loss; depends on whether user gave kwargs
-        loss, loss_log_metrics = self._compute_loss(
-            y=batch['y'],
-            y_pred=y_pred,
-            loss_label="valid_loss",
-        )
-
-        # compute performance; depends on whether user gave kwargs
-        if self.performance_metrics is None:
-            perf_log_metrics = {}
-        else:
-            perf_log_metrics = self._compute_performance(
-                y=batch['y'],
-                y_pred=y_pred,
-                perf_label="valid_perf_",
-            )
-
-        log_metrics = {
-            **loss_log_metrics,
-            **perf_log_metrics,
-        }
-        log_metrics['epoch'] = float(self.current_epoch)
-
-        # The loss and performance is accumulated over an epoch and then
-        # averaged.
-        self.log_dict(  # type: ignore[type]
-            dictionary=log_metrics,
-            on_epoch=True,
-            on_step=False,
-            prog_bar=True,
-        )
-
-        return loss
-
-    def test_step(  # type: ignore[return-value]  # noqa: ANN201
-        self,
-        batch: dict[str, Any],
-        batch_idx: int,  # noqa: ARG002
-        dataloader_idx: int,
-    ):
-        """Compute loss and optional metrics, log metrics and return the log.
-
-        Overrides the method in pl.LightningModule.
-        """
-        loaders = {
-            0: "result_train_",
-            1: "result_valid_",
-            2: "result_eval_",
-        }
-        current_loader = loaders[dataloader_idx]
-
-        forward = getattr(self.model, "forward")  # noqa: B009
-        y_pred = forward(batch['x'])
-
-        # compute loss; depends on whether user gave kwargs
-        _, loss_log_metrics = self._compute_loss(
-            y=batch['y'],
-            y_pred=y_pred,
-            loss_label=current_loader + "loss",
-        )
-
-        # compute performance; depends on whether user gave kwargs
-        if self.performance_metrics is None:
-            perf_log_metrics = {}
-        else:
-            perf_log_metrics = self._compute_performance(
-                y=batch['y'],
-                y_pred=y_pred,
-                perf_label=current_loader + "perf_",
-            )
-
-        log_metrics = {
-            **loss_log_metrics,
-            **perf_log_metrics,
-        }
-
-        # The loss and performance is accumulated over an epoch and then
-        # averaged.
-        self.log_dict(  # type: ignore[type]
-            dictionary=log_metrics,
-            on_epoch=True,
-            on_step=False,
-            prog_bar=True,
-            logger=True,
-            add_dataloader_idx=False,
-        )
-
-        return log_metrics
-
-    def configure_optimizers(self) -> dict[str, Any]:
-        """Return configured optimizer and optional learning rate scheduler.
-
-        Overrides the method in pl.LightningModule.
-        """
-        if self.optimizer:
-            if isinstance(self.optimizer, dict):
-                for optim in self.optimizer:
-                    opt_kwargs = self.optimizer[optim]
-                    optimizer = get_optim(optim)(
-                        params=self.model.parameters(),
-                        lr=self.lr,
-                        **opt_kwargs,
-                    )
-            else:
-                optimizer = get_optim(self.optimizer)(
-                    params=self.model.parameters(),
-                    lr=self.lr,
-                )
-
-        if self.lr_scheduler:
-            if isinstance(self.lr_scheduler, dict):
-                lr_dict = {}
-                for sched in self.lr_scheduler:
-                    sched_kwargs = self.lr_scheduler[sched]
-                    if "monitor" in sched_kwargs:
-                        monitor = sched_kwargs.pop("monitor")
-                        lr_dict["monitor"] = monitor
-                    scheduler = get_lr_scheduler(sched)(
-                        optimizer=optimizer,
-                        **sched_kwargs,
-                    )
-                    lr_dict["scheduler"] = scheduler
-                return {"optimizer": optimizer, "lr_scheduler": lr_dict}
-            scheduler = get_lr_scheduler(self.lr_scheduler)(optimizer=optimizer)
-            return {"optimizer": optimizer, "lr_scheduler": scheduler}
-        return {"optimizer": optimizer}
-
-    def _build_model(self, model: Module, model_params: dict[str, Any]) -> type:
-        """Instantiate a Pytorch model with the given model parameters.
-
-        Parameters
-        ----------
-        model : Module
-            An unitialized Pytorch model class defined in a user's model
-            directory.
-
-        model_params : dict[str, Any]
-            The parameters needed to instantiate the above Pytorch model
-            class.
-
-        Returns
-        -------
-        type
-            A Pytorch model object.
-
-        """
-        return model(**model_params)
-
-    def _compute_loss(
-        self,
-        y: float | Tensor,
-        y_pred: float | Tensor,
-        loss_label: str,
-    ) -> tuple[float | Tensor, dict[str, float | Tensor]]:
-        """Return the loss and the metrics log.
-
-        Parameters
-        ----------
-        y : float | Tensor
-            The target value from a set of training pairs.
-
-        y_pred : float | Tensor
-            The model's prediction.
-
-        loss_label : str
-            Name to be used for labeling purposes.
-
-        Returns
-        -------
-        tuple
-            The computed loss between y and y_pred and the dictionary that
-            logs the loss.
-
-        """
-        log_metrics: dict[str, float | Tensor] = {}
-        loss = None
-
-        # set up loss function once
-        if not hasattr(self, "loss_functions"):
-            self.loss_functions = prepare_function(user_args=self.loss, is_loss=True)
-
-        for _function in self.loss_functions:
-            function, to_argmax, to_flatten = self.loss_functions[_function]
-            if to_argmax:
-                y = argmax(y, dim=1).to(self.device)
-            if to_flatten[0]:
-                y = y.flatten(start_dim=to_flatten[1][0], end_dim=to_flatten[1][1]).to(self.device)
-                y_pred = y_pred.flatten(start_dim=to_flatten[1][0], end_dim=to_flatten[1][1]).to(self.device)
-            loss = function(input=y_pred, target=y)
-            log_metrics[loss_label] = loss
-
-            if self.output_scaler is not None:
-                y_pred = self.output_scaler.inverse_transform(y_pred.clone().detach().cpu()).to(self.device)
-                if not to_argmax:
-                    y = self.output_scaler.inverse_transform(y.clone().detach().cpu()).to(self.device)
-                loss_rescaled = function(input=y_pred, target=y)
-                log_metrics[loss_label] = loss_rescaled
-
-
-        if loss is None:
-            logger.error(
-                "Something went wrong when trying to compute the loss.",
-            )
-            e_msg = "The variable 'loss' cannot be None."
-            raise TypeError(e_msg)
-
-        return loss, log_metrics
-
-    def _compute_performance(
-        self,
-        y: float | Tensor,
-        y_pred: float | Tensor,
-        perf_label: str,
-    ) -> dict[str, float | Tensor]:
-        """Return the performance scores(s) and the metrics log.
-
-        Parameters
-        ----------
-        y : float | tensor
-            The target value from a set of training pairs.
-
-        y_pred : float | tensor
-            The model's prediction.
-
-        perf_label : str
-            Name to be used for labeling purposes.
-
-        Returns
-        -------
-        tuple
-            The computed score between y and y_pred and the dictionary that
-            logs the performance score.
-
-        """
-        log_metrics: dict[str, float | Tensor] = {}
-        if self.performance_metrics is None:
-            logger.error(
-                "Something went wrong when trying to compute the performance\
- metric(s).",
-            )
-            e_msg = "Performance metrics cannot be of NoneType here."
-            raise TypeError(e_msg)
-
-        # set up performance functions once
-        if not hasattr(self, "perf_functions"):
-            self.perf_functions = prepare_function( user_args=self.performance_metrics, is_loss=False)
-
-        for _function in self.perf_functions:
-            function, to_argmax, to_flatten = self.perf_functions[_function]
-            if self.output_scaler is not None:
-                y_pred = self.output_scaler.inverse_transform(y_pred.clone().detach().cpu()).to(self.device)
-                y = self.output_scaler.inverse_transform(y.clone().detach().cpu()).to(self.device)
-            if to_argmax:
-                y = argmax(y, dim=1).to(self.device)
-            if to_flatten[0]:
-                y = y.flatten(start_dim=to_flatten[1][0], end_dim=to_flatten[1][1]).to(self.device)
-                y_pred = y_pred.flatten(start_dim=to_flatten[1][0], end_dim=to_flatten[1][1]).to(self.device)
-            val = function(preds=y_pred, target=y)
-            log_metrics[perf_label + _function] = val
-
-
-        return log_metrics
 
 
 class PLModel_custom(PLModel):


### PR DESCRIPTION
## Epoch-wide Performance Metrics

### Summary

Enables KnowIt to correctly track performance metrics across entire epochs
instead of averaging across batches. This only affected specific performance
metrics (e.g. R2Score, F1Score) where a batch-wise average was inappropriate.
Loss calculations and simpler metrics (e.g. Accuracy) are unaffected.

resolves #190 
resolves #227 

---

### `fetch_torch_mods.py`

- Revamped so that performance metrics are now sourced from `torchmetrics`
  instead of `torchmetrics.functional`.
- Required tensor transformations for specific metrics are now defined in two
  global lookup structures (`ARGMAX_METRICS` and `FLATTEN_METRICS`). These are
  intended to be extended as additional metrics are introduced that require
  specific modifications to predictions or targets before evaluation.
- Loss functions and performance metrics are now packaged and returned as a
  custom dataclass (`PreparedFunction`) instead of being monkey-patched with
  ad-hoc attributes.
- Added a fallback mechanism that translates `snake_case` functional-style
  metric names (e.g. `r2_score`) to their `PascalCase` OO equivalents
  (e.g. `R2Score`), easing the transition from `torchmetrics.functional`.
- General cleanup, refactoring, and documentation.

---

### `pl_model.py`

- Revamped so that performance metrics are accumulated per-batch and computed
  at epoch end using the built-in `update()` / `compute()` / `reset()` pattern
  from `torchmetrics`, rather than being computed per-batch and averaged.
- Added `_loss_combiner` as a placeholder for combining multiple loss functions.
  Previously, defining multiple loss functions caused each to silently overwrite
  the previous. This method currently selects the first loss only and is
  intended to be extended to support weighted combinations in a future PR.

---

### `raw_data_conversion.py`

- Fixed a rare bug when importing data with custom splits that produce singleton
  slices for a particular split.